### PR TITLE
Payments and Assurance: Implement Paginated API for Assurance Claims #41

### DIFF
--- a/ts-assurance-service/src/main/java/assurance/controller/AssuranceController.java
+++ b/ts-assurance-service/src/main/java/assurance/controller/AssuranceController.java
@@ -36,6 +36,27 @@ public class AssuranceController {
         return ok(assuranceService.getAllAssurances(headers));
     }
 
+
+    @CrossOrigin(origins = "*")
+    @GetMapping(path = "/assurances/userid/{userId}")
+    public HttpEntity getUserAssurances(@PathVariable String userId,
+                                       @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
+                                       @RequestParam(value = "size", required = false, defaultValue = "10") Integer size,
+                                       @RequestHeader HttpHeaders headers) {
+        try {
+            UUID.fromString(userId);
+        } catch (IllegalArgumentException e) {
+            AssuranceController.LOGGER.error("[getUserAssurances][Get User's Assurances][UserId is not UUID: {}]", userId);
+            return ok("UserId is not an UUID, please check it and try again");
+        }
+        if (page != null || size != null) {
+            AssuranceController.LOGGER.info("[getUserAssurances][Get User's Assurances Paginated][page: {}, size: {}]", page, size);
+            return ok(assuranceService.getUserAssurancesPage(UUID.fromString(userId), page, size, headers));
+        }
+        AssuranceController.LOGGER.info("[getUserAssurances][Get User's Assurances]");
+        return ok("Invalid page params, page: " + page + ", size: " + size );
+    }
+
     @CrossOrigin(origins = "*")
     @GetMapping(path = "/assurances/types")
     public HttpEntity getAllAssuranceType(@RequestHeader HttpHeaders headers) {

--- a/ts-assurance-service/src/main/java/assurance/repository/AssuranceRepository.java
+++ b/ts-assurance-service/src/main/java/assurance/repository/AssuranceRepository.java
@@ -1,11 +1,14 @@
 package assurance.repository;
 
 import assurance.entity.Assurance;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -55,4 +58,13 @@ public interface AssuranceRepository  extends CrudRepository<Assurance, String> 
      */
     @Override
     ArrayList<Assurance> findAll();
+
+    /**
+     * find all by order id with pagination
+     *
+     * @param orderIds collection of order ids
+     * @param pageable page to return
+     * @return Page<Assurance>
+     */
+    Page<Assurance> findAssurancesByOrderIdIn(Collection<String> orderIds, Pageable pageable);
 }

--- a/ts-assurance-service/src/main/java/assurance/service/AssuranceService.java
+++ b/ts-assurance-service/src/main/java/assurance/service/AssuranceService.java
@@ -1,6 +1,8 @@
 package assurance.service;
 
+import assurance.entity.PlainAssurance;
 import edu.fudan.common.util.Response;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
 
 import javax.transaction.Transactional;
@@ -77,6 +79,11 @@ public interface AssuranceService {
      * @return Response
      */
     Response getAllAssurances(HttpHeaders headers);
+
+    /**
+     * get assurances paginated
+     */
+    Page<PlainAssurance> getUserAssurancesPage(UUID userId, Integer page, Integer size, HttpHeaders headers);
 
     /**
      * get all assurance types

--- a/ts-assurance-service/src/test/java/assurance/controller/AssuranceControllerTest.java
+++ b/ts-assurance-service/src/test/java/assurance/controller/AssuranceControllerTest.java
@@ -1,5 +1,6 @@
 package assurance.controller;
 
+import assurance.entity.PlainAssurance;
 import assurance.service.AssuranceService;
 import com.alibaba.fastjson.JSONObject;
 import edu.fudan.common.util.Response;
@@ -12,15 +13,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.springframework.http.HttpEntity;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 @RunWith(JUnit4.class)
@@ -54,6 +55,23 @@ public class AssuranceControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString();
         Assert.assertEquals(response, JSONObject.parseObject(result, Response.class));
+    }
+
+    @Test
+    public void testGetAssurancesPaginated() throws Exception {
+        PageImpl<PlainAssurance> page = new PageImpl<>(
+                Arrays.asList(new PlainAssurance(), new PlainAssurance()),
+                PageRequest.of(0, 2),
+                3
+        );
+        UUID userId = UUID.randomUUID();
+        Mockito.when(assuranceService.getUserAssurancesPage(Mockito.eq(userId), Mockito.eq(0), Mockito.eq(2), Mockito.any(HttpHeaders.class)))
+                .thenReturn(page);
+        String result = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/assuranceservice/assurances/userid/" + userId + "?page=0&size=2"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        Assert.assertTrue(result.contains("\"content\""));
+        Assert.assertTrue(result.contains("\"totalElements\":3"));
     }
 
     @Test


### PR DESCRIPTION
- Introduced `findAssurancesByOrderIdIn` in `AssuranceRepository` for paginated queries.
- Updated `AssuranceService` and implemented pagination in `AssuranceServiceImpl`.
- Added `getUserAssurancesPage` endpoint in `AssuranceController`.
- Enhanced tests in `AssuranceServiceImplTest` and `AssuranceControllerTest` to validate pagination functionality.

Fixes #41 