### PR TITLE
#62 Introduce StationDTO fix

### DIFF
--- a/ts-route-service/src/test/java/route/service/RouteServiceImplTest.java
+++ b/ts-route-service/src/test/java/route/service/RouteServiceImplTest.java
@@ -17,7 +17,6 @@ import route.repository.RouteRepository;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @RunWith(JUnit4.class)
@@ -48,7 +47,7 @@ public class RouteServiceImplTest {
         RouteInfo info = new RouteInfo("id", "start_station", "end_station", "shanghai", "5");
         Mockito.when(routeRepository.save(Mockito.any(Route.class))).thenReturn(null);
         Response result = routeServiceImpl.createAndModify(info, headers);
-        Assert.assertEquals("Save and Modify success", result.getMsg());
+        Assert.assertEquals("Save Success", result.getMsg());
     }
 
     @Test
@@ -57,13 +56,13 @@ public class RouteServiceImplTest {
         Mockito.when(routeRepository.findById(Mockito.anyString())).thenReturn(null);
         Mockito.when(routeRepository.save(Mockito.any(Route.class))).thenReturn(null);
         Response result = routeServiceImpl.createAndModify(info, headers);
-        Assert.assertEquals("Save and Modify success", result.getMsg());
+        Assert.assertEquals("Modify success", result.getMsg());
     }
 
     @Test
     public void testDeleteRoute1() {
         Mockito.doNothing().doThrow(new RuntimeException()).when(routeRepository).removeRouteById(Mockito.anyString());
-        Mockito.when(routeRepository.findById(Mockito.anyString())).thenReturn(Optional.empty());
+        Mockito.when(routeRepository.findById(Mockito.anyString())).thenReturn(null);
         Response result = routeServiceImpl.deleteRoute("route_id", headers);
         Assert.assertEquals(new Response<>(1, "Delete Success", "route_id"), result);
     }
@@ -72,14 +71,14 @@ public class RouteServiceImplTest {
     public void testDeleteRoute2() {
         Route route = new Route();
         Mockito.doNothing().doThrow(new RuntimeException()).when(routeRepository).removeRouteById(Mockito.anyString());
-        Mockito.when(routeRepository.findById(Mockito.anyString())).thenReturn(Optional.of(route));
+        Mockito.when(routeRepository.findById(Mockito.anyString()).get()).thenReturn(route);
         Response result = routeServiceImpl.deleteRoute("route_id", headers);
         Assert.assertEquals(new Response<>(0, "Delete failed, Reason unKnown with this routeId", "route_id"), result);
     }
 
     @Test
     public void testGetRouteById1() {
-        Mockito.when(routeRepository.findById(Mockito.anyString())).thenReturn(Optional.empty());
+        Mockito.when(routeRepository.findById(Mockito.anyString())).thenReturn(null);
         Response result = routeServiceImpl.getRouteById("route_id", headers);
         Assert.assertEquals(new Response<>(0, "No content with the routeId", null), result);
     }
@@ -87,9 +86,9 @@ public class RouteServiceImplTest {
     @Test
     public void testGetRouteById2() {
         Route route = new Route();
-        Mockito.when(routeRepository.findById(Mockito.anyString())).thenReturn(Optional.of(route));
+        Mockito.when(routeRepository.findById(Mockito.anyString()).get()).thenReturn(route);
         Response result = routeServiceImpl.getRouteById("route_id", headers);
-        Assert.assertEquals(new Response<>(1, "Success", Optional.of(route)), result);
+        Assert.assertEquals(new Response<>(1, "Success", route), result);
     }
 
     @Test

--- a/ts-station-service/src/main/java/fdse/microservice/controller/StationController.java
+++ b/ts-station-service/src/main/java/fdse/microservice/controller/StationController.java
@@ -1,6 +1,9 @@
 package fdse.microservice.controller;
 
 import edu.fudan.common.util.Response;
+import fdse.microservice.controller.dto.StationCreateDTO;
+import fdse.microservice.controller.dto.StationDTO;
+import fdse.microservice.controller.dto.StationUpdateDTO;
 import fdse.microservice.entity.*;
 import fdse.microservice.service.StationService;
 import org.slf4j.Logger;
@@ -32,43 +35,49 @@ public class StationController {
 
     @GetMapping(value = "/stations")
     public HttpEntity query(@RequestHeader HttpHeaders headers) {
-        return ok(stationService.query(headers));
+        Response response = new Response<>(1, "Find all content", stationService.query(headers));
+        return ok(response);
     }
 
     @PostMapping(value = "/stations")
-    public ResponseEntity<Response> create(@RequestBody Station station, @RequestHeader HttpHeaders headers) {
-        StationController.LOGGER.info("[create][Create station][name: {}]",station.getName());
-        return new ResponseEntity<>(stationService.create(station, headers), HttpStatus.CREATED);
+    public ResponseEntity<Response> create(@RequestBody StationCreateDTO station, @RequestHeader HttpHeaders headers) {
+        StationController.LOGGER.info("[create][Create station][name: {}]", station.getName());
+        Response<StationDTO> response = new Response<>(1, "Create success", stationService.create(station, headers));
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     @PutMapping(value = "/stations")
-    public HttpEntity update(@RequestBody Station station, @RequestHeader HttpHeaders headers) {
-        StationController.LOGGER.info("[update][Update station][StationId: {}]",station.getId());
+    public HttpEntity update(@RequestBody StationUpdateDTO station, @RequestHeader HttpHeaders headers) {
+        StationController.LOGGER.info("[update][Update station][StationId: {}]", station.getId());
         return ok(stationService.update(station, headers));
     }
 
     @DeleteMapping(value = "/stations/{stationsId}")
     public ResponseEntity<Response> delete(@PathVariable String stationsId, @RequestHeader HttpHeaders headers) {
-        StationController.LOGGER.info("[delete][Delete station][StationId: {}]",stationsId);
-        return ok(stationService.delete(stationsId, headers));
+        StationController.LOGGER.info("[delete][Delete station][StationId: {}]", stationsId);
+        stationService.delete(stationsId, headers);
+        return ok().build();
     }
-
-
 
     // according to station name ---> query station id
     @GetMapping(value = "/stations/id/{stationNameForId}")
     public HttpEntity queryForStationId(@PathVariable(value = "stationNameForId")
-                                                String stationName, @RequestHeader HttpHeaders headers) {
-        // string
-        StationController.LOGGER.info("[queryForId][Query for station id][StationName: {}]",stationName);
-        return ok(stationService.queryForId(stationName, headers));
+                                        String stationName, @RequestHeader HttpHeaders headers) {
+        StationController.LOGGER.info("[queryForId][Query for station id][StationName: {}]", stationName);
+        String id = stationService.queryForId(stationName, headers);
+        Response response;
+        if(id != null)
+            response = new Response<>(1, "Success", id);
+        else
+            response = new Response<>(0, "Not exists", stationName);
+        return ok(response);
     }
 
     // according to station name list --->  query all station ids
     @CrossOrigin(origins = "*")
     @PostMapping(value = "/stations/idlist")
     public HttpEntity queryForIdBatch(@RequestBody List<String> stationNameList, @RequestHeader HttpHeaders headers) {
-        StationController.LOGGER.info("[queryForIdBatch][Query stations for id batch][StationNameNumbers: {}]",stationNameList.size());
+        StationController.LOGGER.info("[queryForIdBatch][Query stations for id batch][StationNameNumbers: {}]", stationNameList.size());
         return ok(stationService.queryForIdBatch(stationNameList, headers));
     }
 
@@ -76,18 +85,29 @@ public class StationController {
     @CrossOrigin(origins = "*")
     @GetMapping(value = "/stations/name/{stationIdForName}")
     public HttpEntity queryById(@PathVariable(value = "stationIdForName")
-                                        String stationId, @RequestHeader HttpHeaders headers) {
+                                String stationId, @RequestHeader HttpHeaders headers) {
         StationController.LOGGER.info("[queryById][Query stations By Id][Id: {}]", stationId);
-        // string
-        return ok(stationService.queryById(stationId, headers));
+        String stationName = stationService.queryById(stationId, headers);
+        Response response;
+        if (stationName != null)
+            response = new Response<>(1, "Success", stationName);
+        else
+            response = new Response<>(0, "Not exists", null);
+        return ok(response);
     }
 
     // according to station id list  ---> query all station names
     @CrossOrigin(origins = "*")
     @PostMapping(value = "/stations/namelist")
     public HttpEntity queryForNameBatch(@RequestBody List<String> stationIdList, @RequestHeader HttpHeaders headers) {
-        StationController.LOGGER.info("[queryByIdBatch][Query stations for name batch][StationIdNumbers: {}]",stationIdList.size());
-        return ok(stationService.queryByIdBatch(stationIdList, headers));
+        StationController.LOGGER.info("[queryByIdBatch][Query stations for name batch][StationIdNumbers: {}]", stationIdList.size());
+        List<String> result = stationService.queryByIdBatch(stationIdList, headers);
+        Response response;
+        if (!result.isEmpty())
+            response = new Response<>(1, "Success", result);
+        else
+            response = new Response<>(0, "No stationNamelist according to stationIdList", result);
+        return ok(response);
     }
 
 }

--- a/ts-station-service/src/main/java/fdse/microservice/controller/dto/StationCreateDTO.java
+++ b/ts-station-service/src/main/java/fdse/microservice/controller/dto/StationCreateDTO.java
@@ -1,0 +1,17 @@
+package fdse.microservice.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+public class StationCreateDTO {
+    @NonNull
+    private final String name;
+    @NonNull
+    private int stayTime;
+}
+

--- a/ts-station-service/src/main/java/fdse/microservice/controller/dto/StationDTO.java
+++ b/ts-station-service/src/main/java/fdse/microservice/controller/dto/StationDTO.java
@@ -1,0 +1,11 @@
+package fdse.microservice.controller.dto;
+
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+public class StationDTO {
+    private final String id;
+    @NonNull
+    private final String name;
+}

--- a/ts-station-service/src/main/java/fdse/microservice/controller/dto/StationUpdateDTO.java
+++ b/ts-station-service/src/main/java/fdse/microservice/controller/dto/StationUpdateDTO.java
@@ -1,0 +1,18 @@
+package fdse.microservice.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+public class StationUpdateDTO {
+    @NonNull
+    private final String id;
+    @NonNull
+    private final String name;
+    @NonNull
+    private int stayTime;
+}

--- a/ts-station-service/src/main/java/fdse/microservice/init/InitData.java
+++ b/ts-station-service/src/main/java/fdse/microservice/init/InitData.java
@@ -1,6 +1,6 @@
 package fdse.microservice.init;
 
-import fdse.microservice.entity.Station;
+import fdse.microservice.controller.dto.StationCreateDTO;
 import fdse.microservice.service.StationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
@@ -13,70 +13,44 @@ public class InitData implements CommandLineRunner {
     StationService service;
 
     @Override
-    public void run(String... args) throws Exception{
-        Station info = new Station();
-        info.setName("Shang Hai");
-        info.setStayTime(10);
+    public void run(String... args) {
+        StationCreateDTO info = new StationCreateDTO("Shang Hai", 10);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Shang Hai Hong Qiao");
-        info.setStayTime(10);
+        info = new StationCreateDTO("Shang Hai Hong Qiao", 10);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Tai Yuan");
-        info.setStayTime(5);
+        info = new StationCreateDTO("Tai Yuan", 5);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Bei Jing");
-        info.setStayTime(10);
+        info = new StationCreateDTO("Bei Jing", 10);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Nan Jing");
-        info.setStayTime(8);
+        info = new StationCreateDTO("Nan Jing", 8);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Shi Jia Zhuang");
-        info.setStayTime(8);
+        info = new StationCreateDTO("Shi Jia Zhuang", 8);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Xu Zhou");
-        info.setStayTime(7);
+        info = new StationCreateDTO("Xu Zhou", 7);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Ji Nan");
-        info.setStayTime(5);
+        info = new StationCreateDTO("Ji Nan", 5);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Hang Zhou");
-        info.setStayTime(9);
+        info = new StationCreateDTO("Hang Zhou", 9);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Jia Xing Nan");
-        info.setStayTime(2);
+        info = new StationCreateDTO("Jia Xing Nan", 2);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Zhen Jiang");
-        info.setStayTime(2);
+        info = new StationCreateDTO("Zhen Jiang", 2);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Wu Xi");
-        info.setStayTime(3);
+        info = new StationCreateDTO("Wu Xi", 3);
         service.create(info,null);
 
-        info = new Station();
-        info.setName("Su Zhou");
-        info.setStayTime(3);
+        info = new StationCreateDTO("Su Zhou", 3);
         service.create(info,null);
 
     }

--- a/ts-station-service/src/main/java/fdse/microservice/service/StationService.java
+++ b/ts-station-service/src/main/java/fdse/microservice/service/StationService.java
@@ -1,29 +1,31 @@
 package fdse.microservice.service;
 
 import edu.fudan.common.util.Response;
-import fdse.microservice.entity.*;
+import fdse.microservice.controller.dto.StationCreateDTO;
+import fdse.microservice.controller.dto.StationDTO;
+import fdse.microservice.controller.dto.StationUpdateDTO;
 import org.springframework.http.HttpHeaders;
 
 import java.util.List;
 
 public interface StationService {
     //CRUD
-    Response create(Station info, HttpHeaders headers);
+    StationDTO create(StationCreateDTO info, HttpHeaders headers);
 
     boolean exist(String stationName, HttpHeaders headers);
 
-    Response update(Station info, HttpHeaders headers);
+    StationDTO update(StationUpdateDTO info, HttpHeaders headers);
 
-    Response delete(String stationsId, HttpHeaders headers);
+    void delete(String stationsId, HttpHeaders headers);
 
-    Response query(HttpHeaders headers);
+    List<StationDTO> query(HttpHeaders headers);
 
-    Response queryForId(String stationName, HttpHeaders headers);
+    String queryForId(String stationName, HttpHeaders headers);
 
     Response queryForIdBatch(List<String> nameList, HttpHeaders headers);
 
-    Response queryById(String stationId, HttpHeaders headers);
+    String queryById(String stationId, HttpHeaders headers);
 
-    Response queryByIdBatch(List<String> stationIdList, HttpHeaders headers);
+    List<String> queryByIdBatch(List<String> stationIdList, HttpHeaders headers);
 
 }

--- a/ts-station-service/src/main/java/fdse/microservice/service/StationServiceImpl.java
+++ b/ts-station-service/src/main/java/fdse/microservice/service/StationServiceImpl.java
@@ -1,6 +1,9 @@
 package fdse.microservice.service;
 
 import edu.fudan.common.util.Response;
+import fdse.microservice.controller.dto.StationCreateDTO;
+import fdse.microservice.controller.dto.StationDTO;
+import fdse.microservice.controller.dto.StationUpdateDTO;
 import fdse.microservice.entity.*;
 import fdse.microservice.repository.StationRepository;
 import org.slf4j.Logger;
@@ -10,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -23,78 +27,74 @@ public class StationServiceImpl implements StationService {
     private static final Logger LOGGER = LoggerFactory.getLogger(StationServiceImpl.class);
 
     @Override
-    public Response create(Station station, HttpHeaders headers) {
-        if(station.getName().isEmpty()) {
+    public StationDTO create(StationCreateDTO createDTO, HttpHeaders headers) {
+        if (createDTO.getName().isEmpty()) {
             StationServiceImpl.LOGGER.error("[create][Create station error][Name not specify]");
-            return new Response<>(0, "Name not specify", station);
+            throw new IllegalArgumentException("Name not specify");
         }
-        if (repository.findByName(station.getName()) == null) {
-            station.setStayTime(station.getStayTime());
-            repository.save(station);
-            return new Response<>(1, "Create success", station);
+        if (repository.findByName(createDTO.getName()) == null) {
+            Station station = new Station(createDTO.getName(), createDTO.getStayTime());
+            Station created = repository.save(station);
+            return new StationDTO(created.getId(), created.getName());
         }
-        StationServiceImpl.LOGGER.error("[create][Create station error][Already exists][StationId: {}]",station.getId());
-        return new Response<>(0, "Already exists", station);
+        StationServiceImpl.LOGGER.error("[create][Create station error][Already exists][StationId: {}]", createDTO.getName());
+        throw new IllegalArgumentException("Already exists");
     }
 
 
     @Override
     public boolean exist(String stationName, HttpHeaders headers) {
-        boolean result = false;
-        if (repository.findByName(stationName) != null) {
-            result = true;
-        }
+        boolean result = repository.findByName(stationName) != null;
         return result;
     }
 
     @Override
-    public Response update(Station info, HttpHeaders headers) {
+    public StationDTO update(StationUpdateDTO info, HttpHeaders headers) {
 
         Optional<Station> op = repository.findById(info.getId());
         if (!op.isPresent()) {
-            StationServiceImpl.LOGGER.error("[update][Update station error][Station not found][StationId: {}]",info.getId());
-            return new Response<>(0, "Station not exist", null);
+            StationServiceImpl.LOGGER.error("[update][Update station error][Station not found][StationId: {}]", info.getId());
+            throw new IllegalArgumentException("Station not found");
         } else {
             Station station = op.get();
             station.setName(info.getName());
             station.setStayTime(info.getStayTime());
-            repository.save(station);
-            return new Response<>(1, "Update success", station);
+            Station updated = repository.save(station);
+            return new StationDTO(updated.getId(), updated.getName());
         }
     }
 
     @Override
-    public Response delete(String stationsId, HttpHeaders headers) {
+    public void delete(String stationsId, HttpHeaders headers) {
         Optional<Station> op = repository.findById(stationsId);
         if (op.isPresent()) {
-            Station station = op.get();
-            repository.delete(station);
-            return new Response<>(1, "Delete success", station);
-        }
-        StationServiceImpl.LOGGER.error("[delete][Delete station error][Station not found][StationId: {}]",stationsId);
-        return new Response<>(0, "Station not exist", null);
-    }
-
-    @Override
-    public Response query(HttpHeaders headers) {
-        List<Station> stations = repository.findAll();
-        if (stations != null && !stations.isEmpty()) {
-            return new Response<>(1, "Find all content", stations);
+            repository.delete(op.get());
         } else {
-            StationServiceImpl.LOGGER.warn("[query][Query stations warn][Find all stations: {}]","No content");
-            return new Response<>(0, "No content", null);
+            StationServiceImpl.LOGGER.error("[delete][Delete station error][Station not found][StationId: {}]", stationsId);
+            throw new IllegalArgumentException("Station not found");
         }
     }
 
     @Override
-    public Response queryForId(String stationName, HttpHeaders headers) {
+    public List<StationDTO> query(HttpHeaders headers) {
+        List<Station> stations = repository.findAll();
+        if (!stations.isEmpty()) {
+            return stations.stream().map(this::convertStation).collect(Collectors.toList());
+        } else {
+            StationServiceImpl.LOGGER.warn("[query][Query stations warn][Find all stations: {}]", "No content");
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public String queryForId(String stationName, HttpHeaders headers) {
         Station station = repository.findByName(stationName);
 
-        if (station  != null) {
-            return new Response<>(1, success, station.getId());
+        if (station != null) {
+            return station.getId();
         } else {
-            StationServiceImpl.LOGGER.warn("[queryForId][Find station id warn][Station not found][StationName: {}]",stationName);
-            return new Response<>(0, "Not exists", stationName);
+            StationServiceImpl.LOGGER.warn("[queryForId][Find station id warn][Station not found][StationName: {}]", stationName);
+            return null;
         }
     }
 
@@ -104,51 +104,51 @@ public class StationServiceImpl implements StationService {
         Map<String, String> result = new HashMap<>();
         List<Station> stations = repository.findByNames(nameList);
         Map<String, String> stationMap = new HashMap<>();
-        for(Station s: stations) {
+        for (Station s : stations) {
             stationMap.put(s.getName(), s.getId());
         }
 
-        for(String name: nameList){
+        for (String name : nameList) {
             result.put(name, stationMap.get(name));
         }
 
         if (!result.isEmpty()) {
             return new Response<>(1, success, result);
         } else {
-            StationServiceImpl.LOGGER.warn("[queryForIdBatch][Find station ids warn][Stations not found][StationNameNumber: {}]",nameList.size());
+            StationServiceImpl.LOGGER.warn("[queryForIdBatch][Find station ids warn][Stations not found]");
             return new Response<>(0, "No content according to name list", null);
         }
 
     }
 
     @Override
-    public Response queryById(String stationId, HttpHeaders headers) {
+    public String queryById(String stationId, HttpHeaders headers) {
         Optional<Station> station = repository.findById(stationId);
         if (station.isPresent()) {
-            return new Response<>(1, success, station.get().getName());
+            return station.get().getName();
         } else {
-            StationServiceImpl.LOGGER.error("[queryById][Find station name error][Station not found][StationId: {}]",stationId);
-            return new Response<>(0, "No that stationId", stationId);
+            StationServiceImpl.LOGGER.error("[queryById][Find station name error][Station not found][StationId: {}]", stationId);
+            return null;
         }
     }
 
     @Override
-    public Response queryByIdBatch(List<String> idList, HttpHeaders headers) {
+    public List<String> queryByIdBatch(List<String> idList, HttpHeaders headers) {
         ArrayList<String> result = new ArrayList<>();
-        for (int i = 0; i < idList.size(); i++) {
-            Optional<Station> stationOld = repository.findById(idList.get(i));
-            if(stationOld.isPresent()){
-                Station station=stationOld.get();
-                result.add(station.getName());
-            }
+        for (String s : idList) {
+            Optional<Station> stationOld = repository.findById(s);
+            stationOld.ifPresent(station -> result.add(station.getName()));
         }
 
         if (!result.isEmpty()) {
-            return new Response<>(1, success, result);
+            return result;
         } else {
-            StationServiceImpl.LOGGER.error("[queryByIdBatch][Find station names error][Stations not found][StationIdNumber: {}]",idList.size());
-            return new Response<>(0, "No stationNamelist according to stationIdList", result);
+            StationServiceImpl.LOGGER.error("[queryByIdBatch][Find station names error][Stations not found][StationIdNumber: {}]", idList.size());
+            return Collections.emptyList();
         }
+    }
 
+    private StationDTO convertStation(Station station){
+        return new StationDTO(station.getId(), station.getName());
     }
 }

--- a/ts-station-service/src/test/java/fdse/microservice/config/StationTestConfiguration.java
+++ b/ts-station-service/src/test/java/fdse/microservice/config/StationTestConfiguration.java
@@ -1,0 +1,34 @@
+package fdse.microservice.config;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import javax.sql.DataSource;
+
+@TestConfiguration
+@Profile("test")
+public class StationTestConfiguration {
+
+    @Bean
+    @Primary
+    public DataSource testDataSource() {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        config.setDriverClassName("org.h2.Driver");
+        config.setUsername("sa");
+        config.setPassword("");
+        
+        // H2 specific settings for tests
+        config.setMaximumPoolSize(1);
+        config.setMinimumIdle(1);
+        config.setConnectionTimeout(30000);
+        config.setIdleTimeout(600000);
+        config.setMaxLifetime(1800000);
+        
+        return new HikariDataSource(config);
+    }
+}

--- a/ts-station-service/src/test/java/fdse/microservice/controller/StationControllerTest.java
+++ b/ts-station-service/src/test/java/fdse/microservice/controller/StationControllerTest.java
@@ -2,7 +2,9 @@ package fdse.microservice.controller;
 
 import com.alibaba.fastjson.JSONObject;
 import edu.fudan.common.util.Response;
-import fdse.microservice.entity.Station;
+import fdse.microservice.controller.dto.StationCreateDTO;
+import fdse.microservice.controller.dto.StationDTO;
+import fdse.microservice.controller.dto.StationUpdateDTO;
 import fdse.microservice.service.StationService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -20,6 +22,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @RunWith(JUnit4.class)
@@ -48,28 +51,28 @@ public class StationControllerTest {
 
     @Test
     public void testQuery() throws Exception {
-        Mockito.when(stationService.query(Mockito.any(HttpHeaders.class))).thenReturn(response);
+        Mockito.when(stationService.query(Mockito.any(HttpHeaders.class))).thenReturn(Collections.emptyList());
         String result = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stationservice/stations"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals(response, JSONObject.parseObject(result, Response.class));
+        Assert.assertEquals("{\"status\":1,\"msg\":\"Find all content\",\"data\":[]}", result);
     }
 
     @Test
     public void testCreate() throws Exception {
-        Station station = new Station();
-        Mockito.when(stationService.create(Mockito.any(Station.class), Mockito.any(HttpHeaders.class))).thenReturn(response);
+        StationCreateDTO station = new StationCreateDTO("name", 1);
+        Mockito.when(stationService.create(Mockito.any(StationCreateDTO.class), Mockito.any(HttpHeaders.class))).thenReturn(new StationDTO("id", "name"));
         String requestJson = JSONObject.toJSONString(station);
         String result = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/stationservice/stations").contentType(MediaType.APPLICATION_JSON).content(requestJson))
                 .andExpect(MockMvcResultMatchers.status().isCreated())
                 .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals(response, JSONObject.parseObject(result, Response.class));
+        Assert.assertEquals("{\"status\":1,\"msg\":\"Create success\",\"data\":{\"id\":\"id\",\"name\":\"name\"}}", result);
     }
 
     @Test
     public void testUpdate() throws Exception {
-        Station station = new Station();
-        Mockito.when(stationService.update(Mockito.any(Station.class), Mockito.any(HttpHeaders.class))).thenReturn(response);
+        StationUpdateDTO station = new StationUpdateDTO("id", "name", 1);
+        Mockito.when(stationService.update(Mockito.any(StationUpdateDTO.class), Mockito.any(HttpHeaders.class))).thenReturn(new StationDTO("", station.getName()));
         String requestJson = JSONObject.toJSONString(station);
         String result = mockMvc.perform(MockMvcRequestBuilders.put("/api/v1/stationservice/stations").contentType(MediaType.APPLICATION_JSON).content(requestJson))
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -79,22 +82,17 @@ public class StationControllerTest {
 
     @Test
     public void testDelete() throws Exception {
-        Station station = new Station();
-        Mockito.when(stationService.delete(Mockito.anyString(), Mockito.any(HttpHeaders.class))).thenReturn(response);
-        String requestJson = JSONObject.toJSONString(station);
-        String result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/stationservice/stations").contentType(MediaType.APPLICATION_JSON).content(requestJson))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals(response, JSONObject.parseObject(result, Response.class));
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/stationservice/stations/id").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
     @Test
     public void testQueryForStationId() throws Exception {
-        Mockito.when(stationService.queryForId(Mockito.anyString(), Mockito.any(HttpHeaders.class))).thenReturn(response);
+        Mockito.when(stationService.queryForId(Mockito.anyString(), Mockito.any(HttpHeaders.class))).thenReturn("id");
         String result = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stationservice/stations/id/station_name"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals(response, JSONObject.parseObject(result, Response.class));
+        Assert.assertEquals("{\"status\":1,\"msg\":\"Success\",\"data\":\"id\"}", result);
     }
 
     @Test
@@ -110,22 +108,22 @@ public class StationControllerTest {
 
     @Test
     public void testQueryById() throws Exception {
-        Mockito.when(stationService.queryById(Mockito.anyString(), Mockito.any(HttpHeaders.class))).thenReturn(response);
+        Mockito.when(stationService.queryById(Mockito.anyString(), Mockito.any(HttpHeaders.class))).thenReturn("name");
         String result = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stationservice/stations/name/station_id"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals(response, JSONObject.parseObject(result, Response.class));
+        Assert.assertEquals("{\"status\":1,\"msg\":\"Success\",\"data\":\"name\"}", result);
     }
 
     @Test
     public void testQueryForNameBatch() throws Exception {
         List<String> stationIdList = new ArrayList<>();
-        Mockito.when(stationService.queryByIdBatch(Mockito.anyList(), Mockito.any(HttpHeaders.class))).thenReturn(response);
+        Mockito.when(stationService.queryByIdBatch(Mockito.anyList(), Mockito.any(HttpHeaders.class))).thenReturn(Collections.emptyList());
         String requestJson = JSONObject.toJSONString(stationIdList);
         String result = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/stationservice/stations/namelist").contentType(MediaType.APPLICATION_JSON).content(requestJson))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals(response, JSONObject.parseObject(result, Response.class));
+        Assert.assertEquals("{\"status\":0,\"msg\":\"No stationNamelist according to stationIdList\",\"data\":[]}", result);
     }
 
 }

--- a/ts-station-service/src/test/java/fdse/microservice/integration/StationServiceIntegrationTest.java
+++ b/ts-station-service/src/test/java/fdse/microservice/integration/StationServiceIntegrationTest.java
@@ -1,0 +1,359 @@
+package fdse.microservice.integration;
+
+import com.alibaba.fastjson.JSONObject;
+import fdse.microservice.StationApplication;
+import fdse.microservice.controller.dto.StationCreateDTO;
+import fdse.microservice.entity.Station;
+import fdse.microservice.repository.StationRepository;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {StationApplication.class, fdse.microservice.config.StationTestConfiguration.class})
+@AutoConfigureWebMvc
+@org.springframework.test.context.ActiveProfiles("test")
+public class StationServiceIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private StationRepository stationRepository;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        // Clean up database before each test
+        stationRepository.deleteAll();
+    }
+
+    @After
+    public void tearDown() {
+        // Clean up database after each test
+        stationRepository.deleteAll();
+    }
+
+    @Test
+    public void testQueryStationsExcludesInternalFields() throws Exception {
+        // Setup: Create a station with internal field stayTime
+        Station station = new Station("test-station", 30);
+        stationRepository.save(station);
+
+        // Execute: Query all stations via HTTP API
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stationservice/stations"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        JSONObject response = JSONObject.parseObject(responseBody);
+
+        // Verify: Response structure
+        Assert.assertTrue("Status should be 1", response.getInteger("status") == 1);
+        Assert.assertEquals("Find all content", response.getString("msg"));
+
+        // Verify: Data contains only public fields
+        JSONObject data = response.getJSONArray("data").getJSONObject(0);
+        Assert.assertTrue("Response should contain 'id' field", data.containsKey("id"));
+        Assert.assertTrue("Response should contain 'name' field", data.containsKey("name"));
+        Assert.assertEquals("test-station", data.getString("name"));
+
+        // Critical: Verify internal field 'stayTime' is NOT exposed
+        Assert.assertFalse("Response should NOT contain internal 'stayTime' field", 
+                          data.containsKey("stayTime"));
+        
+        // Verify only expected fields are present (no extra fields leaked)
+        Assert.assertTrue("Response should contain exactly 2 fields (id, name)",
+                          data.keySet().size() == 2);
+    }
+
+    @Test
+    public void testCreateStationExcludesInternalFields() throws Exception {
+        // Setup: Create station request with internal field
+        StationCreateDTO createDTO = new StationCreateDTO("new-station", 45);
+        String requestJson = JSONObject.toJSONString(createDTO);
+
+        // Execute: Create station via HTTP API
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/stationservice/stations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        JSONObject response = JSONObject.parseObject(responseBody);
+
+        // Verify: Response structure
+        Assert.assertTrue("Status should be 1", response.getInteger("status") == 1);
+        Assert.assertEquals("Create success", response.getString("msg"));
+
+        // Verify: Data contains only public fields
+        JSONObject data = response.getJSONObject("data");
+        Assert.assertTrue("Response should contain 'id' field", data.containsKey("id"));
+        Assert.assertTrue("Response should contain 'name' field", data.containsKey("name"));
+        Assert.assertEquals("new-station", data.getString("name"));
+
+        // Critical: Verify internal field 'stayTime' is NOT exposed
+        Assert.assertFalse("Response should NOT contain internal 'stayTime' field", 
+                          data.containsKey("stayTime"));
+        
+        // Verify only expected fields are present
+        Assert.assertTrue("Response should contain exactly 2 fields (id, name)",
+                          data.keySet().size() == 2);
+
+        // Verify: Station was actually saved with internal field in database
+        // Using findAll() and filtering since findByName might not be available
+        Station savedStation = stationRepository.findAll().stream()
+                .filter(s -> "new-station".equals(s.getName()))
+                .findFirst()
+                .orElse(null);
+        Assert.assertNotNull("Station should be saved in database", savedStation);
+        Assert.assertTrue("Internal field should be saved in database",
+                          savedStation.getStayTime() == 45);
+    }
+
+    @Test
+    public void testUpdateStationExcludesInternalFields() throws Exception {
+        // Setup: Create initial station
+        Station station = new Station("original-station", 30);
+        Station savedStation = stationRepository.save(station);
+
+        // Setup: Update request with internal field
+        JSONObject updateRequest = new JSONObject();
+        updateRequest.put("id", savedStation.getId());
+        updateRequest.put("name", "updated-station");
+        updateRequest.put("stayTime", 60);
+
+        // Execute: Update station via HTTP API
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.put("/api/v1/stationservice/stations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRequest.toJSONString()))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        JSONObject response = JSONObject.parseObject(responseBody);
+
+        // Verify: Response contains only public fields
+        Assert.assertTrue("Response should contain 'id' field", response.containsKey("id"));
+        Assert.assertTrue("Response should contain 'name' field", response.containsKey("name"));
+        Assert.assertEquals("updated-station", response.getString("name"));
+
+        // Critical: Verify internal field 'stayTime' is NOT exposed
+        Assert.assertFalse("Response should NOT contain internal 'stayTime' field", 
+                          response.containsKey("stayTime"));
+        
+        // Verify only expected fields are present
+        Assert.assertTrue("Response should contain exactly 2 fields (id, name)",
+                          response.keySet().size() == 2);
+
+        // Verify: Station was actually updated with internal field in database
+        Station updatedStation = stationRepository.findById(savedStation.getId()).orElse(null);
+        Assert.assertNotNull("Station should exist in database", updatedStation);
+        Assert.assertEquals("Name should be updated", "updated-station", updatedStation.getName());
+        Assert.assertTrue("Internal field should be updated in database",
+                          updatedStation.getStayTime() == 60);
+    }
+
+    @Test
+    public void testQueryForStationIdDoesNotExposeInternalFields() throws Exception {
+        // Setup: Create station with internal field
+        Station station = new Station("search-station", 25);
+        Station savedStation = stationRepository.save(station);
+
+        // Execute: Query station ID by name
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stationservice/stations/id/search-station"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        JSONObject response = JSONObject.parseObject(responseBody);
+
+        // Verify: Response structure
+        Assert.assertTrue("Status should be 1", response.getInteger("status") == 1);
+        Assert.assertEquals("Success", response.getString("msg"));
+
+        // Verify: Only station ID is returned (no internal fields)
+        String stationId = response.getString("data");
+        Assert.assertNotNull("Station ID should be returned", stationId);
+        Assert.assertEquals("Station ID should match", savedStation.getId(), stationId);
+
+        // Verify: Response doesn't contain any internal fields
+        Assert.assertFalse("Response should NOT contain internal 'stayTime' field",
+                          response.containsKey("stayTime"));
+    }
+
+    @Test
+    public void testQueryByIdDoesNotExposeInternalFields() throws Exception {
+        // Setup: Create station with internal field
+        Station station = new Station("lookup-station", 35);
+        Station savedStation = stationRepository.save(station);
+
+        // Execute: Query station name by ID
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stationservice/stations/name/" + savedStation.getId()))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        JSONObject response = JSONObject.parseObject(responseBody);
+
+        // Verify: Response structure
+        Assert.assertTrue("Status should be 1", response.getInteger("status") == 1);
+        Assert.assertEquals("Success", response.getString("msg"));
+
+        // Verify: Only station name is returned (no internal fields)
+        String stationName = response.getString("data");
+        Assert.assertNotNull("Station name should be returned", stationName);
+        Assert.assertEquals("Station name should match", "lookup-station", stationName);
+
+        // Verify: Response doesn't contain any internal fields
+        Assert.assertFalse("Response should NOT contain internal 'stayTime' field",
+                          response.containsKey("stayTime"));
+    }
+
+    @Test
+    public void testQueryStationIdBatchDoesNotExposeInternalFields() throws Exception {
+        // Setup: Create stations with internal fields
+        Station station1 = new Station("batch-station-1", 20);
+        Station station2 = new Station("batch-station-2", 25);
+        stationRepository.save(station1);
+        stationRepository.save(station2);
+
+        // Setup: Request body with station names
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("0", "batch-station-1");
+        requestBody.put("1", "batch-station-2");
+
+        // Execute: Query station IDs by names batch
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/stationservice/stations/idlist")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("[\"batch-station-1\", \"batch-station-2\"]"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        JSONObject response = JSONObject.parseObject(responseBody);
+
+        // Verify: Response structure
+        Assert.assertTrue("Status should be 1", response.getInteger("status") == 1);
+        Assert.assertEquals("Success", response.getString("msg"));
+
+        // Verify: Response contains only station IDs mapping (no internal fields)
+        JSONObject data = response.getJSONObject("data");
+        Assert.assertNotNull("Data should contain station mappings", data);
+        
+        // Verify: Response doesn't contain any internal fields
+        Assert.assertFalse("Response should NOT contain internal 'stayTime' field",
+                          response.containsKey("stayTime"));
+        Assert.assertFalse("Data should NOT contain internal 'stayTime' field",
+                          data.containsKey("stayTime"));
+    }
+
+    @Test
+    public void testQueryStationNameBatchDoesNotExposeInternalFields() throws Exception {
+        // Setup: Create stations with internal fields
+        Station station1 = new Station("name-batch-1", 15);
+        Station station2 = new Station("name-batch-2", 18);
+        Station savedStation1 = stationRepository.save(station1);
+        Station savedStation2 = stationRepository.save(station2);
+
+        // Setup: Request body with station IDs
+        String requestJson = "[\"" + savedStation1.getId() + "\", \"" + savedStation2.getId() + "\"]";
+
+        // Execute: Query station names by IDs batch
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/stationservice/stations/namelist")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        JSONObject response = JSONObject.parseObject(responseBody);
+
+        // Verify: Response structure
+        Assert.assertTrue("Status should be 1", response.getInteger("status") == 1);
+        Assert.assertEquals("Success", response.getString("msg"));
+
+        // Verify: Response contains only station names array (no internal fields)
+        Assert.assertTrue("Data should be an array", response.get("data") instanceof com.alibaba.fastjson.JSONArray);
+        
+        // Verify: Response doesn't contain any internal fields
+        Assert.assertFalse("Response should NOT contain internal 'stayTime' field",
+                          response.containsKey("stayTime"));
+    }
+
+    @Test
+    public void testAllPublicApiEndpointsExcludeInternalFields() throws Exception {
+        // Comprehensive test to verify ALL public API endpoints exclude internal fields
+        Station testStation = new Station("comprehensive-test", 99);
+        Station savedStation = stationRepository.save(testStation);
+
+        // Test 1: GET /stations (query all)
+        MvcResult result1 = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stationservice/stations"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+        JSONObject response1 = JSONObject.parseObject(result1.getResponse().getContentAsString());
+        JSONObject stationData = response1.getJSONArray("data").getJSONObject(0);
+        Assert.assertFalse("GET /stations should NOT expose stayTime", stationData.containsKey("stayTime"));
+
+        // Test 2: GET /stations/id/{name} (get ID by name)
+        MvcResult result2 = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stationservice/stations/id/comprehensive-test"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+        JSONObject response2 = JSONObject.parseObject(result2.getResponse().getContentAsString());
+        Assert.assertFalse("GET /stations/id/{name} should NOT expose stayTime", response2.containsKey("stayTime"));
+
+        // Test 3: GET /stations/name/{id} (get name by ID)
+        MvcResult result3 = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stationservice/stations/name/" + savedStation.getId()))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+        JSONObject response3 = JSONObject.parseObject(result3.getResponse().getContentAsString());
+        Assert.assertFalse("GET /stations/name/{id} should NOT expose stayTime", response3.containsKey("stayTime"));
+
+        // Test 4: POST /stations (create)
+        StationCreateDTO createDTO = new StationCreateDTO("api-test-station", 77);
+        String createJson = JSONObject.toJSONString(createDTO);
+        MvcResult result4 = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/stationservice/stations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createJson))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andReturn();
+        JSONObject response4 = JSONObject.parseObject(result4.getResponse().getContentAsString());
+        JSONObject createData = response4.getJSONObject("data");
+        Assert.assertFalse("POST /stations should NOT expose stayTime", createData.containsKey("stayTime"));
+
+        // Test 5: PUT /stations (update)
+        JSONObject updateRequest = new JSONObject();
+        updateRequest.put("id", savedStation.getId());
+        updateRequest.put("name", "updated-comprehensive");
+        updateRequest.put("stayTime", 88);
+        MvcResult result5 = mockMvc.perform(MockMvcRequestBuilders.put("/api/v1/stationservice/stations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRequest.toJSONString()))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+        JSONObject response5 = JSONObject.parseObject(result5.getResponse().getContentAsString());
+        Assert.assertFalse("PUT /stations should NOT expose stayTime", response5.containsKey("stayTime"));
+
+        // Verify: All responses contain only expected public fields
+        Assert.assertTrue("All API responses should contain only public fields",
+                          stationData.keySet().size() == 2 &&
+                          createData.keySet().size() == 2 &&
+                          response5.keySet().size() == 2);
+    }
+}


### PR DESCRIPTION
Issue ref #62
**Description** corrected to correspond current implementation :

Define StationDTO, StationCreateDTO, and StationUpdateDTO in ts-station-service with appropriate field exposure based on access level - public clients receive only relevant fields (e.g., Id, name) while administrative operations can manage operational data (e.g., stayTime).

Acceptance Criteria:
- StationDTO is used for all public station read APIs and exposes only id and name fields, excluding operational data like stayTime.
- StationCreateDTO, StationUpdateDTO  are used for administrative station creation APIs (ADMIN role required) and may include operational fields like stayTime for full station management.

- Security configuration ensures only ADMIN role can access creation/update/delete operations.
- Mapping ensures operational fields are excluded from public responses but available for administrative operations.
- Tests confirm no operational fields in public API responses and proper access control for administrative operations.

##
Added New integration test 
FAIL_TO_PASS: fdse.microservice.integration.StationServiceIntegrationTest