### PR TITLE
Order Management:  Implement Order Search by Account and Travel Date (JPA, Spring Data)

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,11 @@
   "jvm_version": "8",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "ts-order-service:order.controller.OrderControllerTest#testQueryOrdersByAccountAndTravelDate",
+      "ts-order-service:order.service.OrderServiceImplTest#testQueryOrdersByAccountAndTravelDate1",
+      "ts-order-service:order.service.OrderServiceImplTest#testQueryOrdersByAccountAndTravelDate2"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/ts-order-service/src/main/java/order/controller/OrderController.java
+++ b/ts-order-service/src/main/java/order/controller/OrderController.java
@@ -11,8 +11,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Date;
-
 import static org.springframework.http.ResponseEntity.ok;
 
 /**
@@ -67,6 +65,19 @@ public class OrderController {
                                             @RequestHeader HttpHeaders headers) {
         OrderController.LOGGER.info("[queryOrdersForRefresh][Query Orders][for LoginId:{}]", qi.getLoginId());
         return ok(orderService.queryOrdersForRefresh(qi, qi.getLoginId(), headers));
+    }
+    
+    @CrossOrigin(origins = "*")
+    @PostMapping(path = "/order/byDate")
+    public HttpEntity queryOrdersByAccountAndTravelDate(@RequestBody OrderByAccountAndDateRangeInfo queryInfo,
+                                                       @RequestHeader HttpHeaders headers) {
+        OrderController.LOGGER.info("[queryOrdersByAccountAndTravelDate][Query Orders By Date][AccountId: {}, StartDate: {}, EndDate: {}]", 
+                                   queryInfo.getAccountId(), queryInfo.getStartDate(), queryInfo.getEndDate());
+
+        return ok(orderService.queryOrdersByAccountAndTravelDate(queryInfo.getAccountId(),
+                                                               queryInfo.getStartDate(), 
+                                                               queryInfo.getEndDate(), 
+                                                               headers));
     }
 
     @CrossOrigin(origins = "*")

--- a/ts-order-service/src/main/java/order/entity/OrderByAccountAndDateRangeInfo.java
+++ b/ts-order-service/src/main/java/order/entity/OrderByAccountAndDateRangeInfo.java
@@ -1,0 +1,19 @@
+package order.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * Request entity for querying orders by account and travel date range
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderByAccountAndDateRangeInfo {
+    private String accountId;
+    private Date startDate;
+    private Date endDate;
+}

--- a/ts-order-service/src/main/java/order/repository/OrderRepository.java
+++ b/ts-order-service/src/main/java/order/repository/OrderRepository.java
@@ -2,12 +2,12 @@ package order.repository;
 
 import order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Optional;
-import java.util.UUID;
 
 /**
  * @author fdse
@@ -24,6 +24,19 @@ public interface OrderRepository extends JpaRepository<Order, String> {
     ArrayList<Order> findByAccountId(String accountId);
 
     ArrayList<Order> findByTravelDateAndTrainNumber(String travelDate,String trainNumber);
+    
+    /**
+     * Find orders by account ID and travel date range.
+     * Note: travelDate is stored as String in format yyyy-MM-dd, so string comparison works for date ranges.
+     * @param accountId the account ID to search for
+     * @param startDate the start date (inclusive) in yyyy-MM-dd format
+     * @param endDate the end date (inclusive) in yyyy-MM-dd format
+     * @return list of orders matching the criteria
+     */
+    @Query("SELECT o FROM Order o WHERE o.accountId = :accountId AND o.travelDate >= :startDate AND o.travelDate <= :endDate")
+    ArrayList<Order> findByAccountIdAndTravelDateBetween(@Param("accountId") String accountId, 
+                                                        @Param("startDate") String startDate, 
+                                                        @Param("endDate") String endDate);
 
     @Override
     void deleteById(String id);

--- a/ts-order-service/src/main/java/order/service/OrderService.java
+++ b/ts-order-service/src/main/java/order/service/OrderService.java
@@ -50,4 +50,6 @@ public interface OrderService {
     Response addNewOrder(Order order, HttpHeaders headers);
 
     Response updateOrder(Order order, HttpHeaders headers);
+    
+    Response queryOrdersByAccountAndTravelDate(String accountId, Date startDate, Date endDate, HttpHeaders headers);
 }

--- a/ts-order-service/src/test/java/order/service/OrderServiceImplTest.java
+++ b/ts-order-service/src/test/java/order/service/OrderServiceImplTest.java
@@ -373,4 +373,245 @@ public class OrderServiceImplTest {
         Assert.assertEquals("Admin Update Order Success", result.getMsg());
     }
 
+    @Test
+    public void testQueryOrdersByAccountAndTravelDate1() {
+        // Arrange
+        String accountId = "user_id_1";
+        Date startDate = new Date();
+        Date endDate = new Date(startDate.getTime() + 86400000); // next day
+        HttpHeaders headers = new HttpHeaders();
+        
+        ArrayList<Order> mockOrders = new ArrayList<>();
+        Order mockOrder = new Order();
+        mockOrder.setAccountId(accountId);
+        mockOrder.setTravelDate("2023-05-05");
+        mockOrders.add(mockOrder);
+        
+        // Mock repository response
+        Mockito.when(orderRepository.findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+            .thenReturn(mockOrders);
+        
+        // Act
+        Response response = orderServiceImpl.queryOrdersByAccountAndTravelDate(accountId, startDate, endDate, headers);
+        
+        // Assert
+        Assert.assertNotNull(response);
+        Assert.assertEquals(new Integer(1), response.getStatus());
+        Assert.assertEquals("Query Orders By Account And Travel Date Success", response.getMsg());
+        Assert.assertEquals(mockOrders, response.getData());
+        
+        // Verify repository was called
+        Mockito.verify(orderRepository, times(1)).findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+    
+    @Test
+    public void testQueryOrdersByAccountAndTravelDate2() {
+        // Arrange
+        String accountId = "user_id_1";
+        Date startDate = new Date();
+        Date endDate = new Date(startDate.getTime() + 86400000); // next day
+        HttpHeaders headers = new HttpHeaders();
+        
+        // Empty result
+        ArrayList<Order> emptyOrders = new ArrayList<>();
+        
+        // Mock repository response - empty list
+        Mockito.when(orderRepository.findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+            .thenReturn(emptyOrders);
+        
+        // Act
+        Response response = orderServiceImpl.queryOrdersByAccountAndTravelDate(accountId, startDate, endDate, headers);
+        
+        // Assert
+        Assert.assertNotNull(response);
+        Assert.assertEquals(new Integer(1), response.getStatus());
+        Assert.assertEquals("No orders found for the specified criteria", response.getMsg());
+        Assert.assertNotNull(response.getData());
+        Assert.assertEquals(0, ((ArrayList<Order>)response.getData()).size());
+        
+        // Verify repository was called
+        Mockito.verify(orderRepository, times(1)).findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+    
+    @Test
+    public void testQueryOrdersByAccountAndTravelDateWithNullAccountId() {
+        // Arrange
+        String accountId = null;
+        Date startDate = new Date();
+        Date endDate = new Date(startDate.getTime() + 86400000);
+        HttpHeaders headers = new HttpHeaders();
+        
+        // Act
+        Response response = orderServiceImpl.queryOrdersByAccountAndTravelDate(accountId, startDate, endDate, headers);
+        
+        // Assert
+        Assert.assertNotNull(response);
+        Assert.assertEquals(new Integer(0), response.getStatus());
+        Assert.assertEquals("Account ID cannot be null or empty", response.getMsg());
+        Assert.assertNull(response.getData());
+        
+        // Verify repository was NOT called
+        Mockito.verify(orderRepository, times(0)).findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+    
+    @Test
+    public void testQueryOrdersByAccountAndTravelDateWithEmptyAccountId() {
+        // Arrange
+        String accountId = "   ";
+        Date startDate = new Date();
+        Date endDate = new Date(startDate.getTime() + 86400000);
+        HttpHeaders headers = new HttpHeaders();
+        
+        // Act
+        Response response = orderServiceImpl.queryOrdersByAccountAndTravelDate(accountId, startDate, endDate, headers);
+        
+        // Assert
+        Assert.assertNotNull(response);
+        Assert.assertEquals(new Integer(0), response.getStatus());
+        Assert.assertEquals("Account ID cannot be null or empty", response.getMsg());
+        Assert.assertNull(response.getData());
+        
+        // Verify repository was NOT called
+        Mockito.verify(orderRepository, times(0)).findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+    
+    @Test
+    public void testQueryOrdersByAccountAndTravelDateWithNullStartDate() {
+        // Arrange
+        String accountId = "user_id_1";
+        Date startDate = null;
+        Date endDate = new Date();
+        HttpHeaders headers = new HttpHeaders();
+        
+        // Act
+        Response response = orderServiceImpl.queryOrdersByAccountAndTravelDate(accountId, startDate, endDate, headers);
+        
+        // Assert
+        Assert.assertNotNull(response);
+        Assert.assertEquals(new Integer(0), response.getStatus());
+        Assert.assertEquals("Start date cannot be null", response.getMsg());
+        Assert.assertNull(response.getData());
+        
+        // Verify repository was NOT called
+        Mockito.verify(orderRepository, times(0)).findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+    
+    @Test
+    public void testQueryOrdersByAccountAndTravelDateWithNullEndDate() {
+        // Arrange
+        String accountId = "user_id_1";
+        Date startDate = new Date();
+        Date endDate = null;
+        HttpHeaders headers = new HttpHeaders();
+        
+        // Act
+        Response response = orderServiceImpl.queryOrdersByAccountAndTravelDate(accountId, startDate, endDate, headers);
+        
+        // Assert
+        Assert.assertNotNull(response);
+        Assert.assertEquals(new Integer(0), response.getStatus());
+        Assert.assertEquals("End date cannot be null", response.getMsg());
+        Assert.assertNull(response.getData());
+        
+        // Verify repository was NOT called
+        Mockito.verify(orderRepository, times(0)).findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+    
+    @Test
+    public void testQueryOrdersByAccountAndTravelDateWithInvalidDateRange() {
+        // Arrange
+        String accountId = "user_id_1";
+        Date startDate = new Date(System.currentTimeMillis() + 86400000); // tomorrow
+        Date endDate = new Date(); // today - invalid range
+        HttpHeaders headers = new HttpHeaders();
+        
+        // Act
+        Response response = orderServiceImpl.queryOrdersByAccountAndTravelDate(accountId, startDate, endDate, headers);
+        
+        // Assert
+        Assert.assertNotNull(response);
+        Assert.assertEquals(new Integer(0), response.getStatus());
+        Assert.assertEquals("Start date must be before or equal to end date", response.getMsg());
+        Assert.assertNull(response.getData());
+        
+        // Verify repository was NOT called
+        Mockito.verify(orderRepository, times(0)).findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+    
+    @Test
+    public void testQueryOrdersByAccountAndTravelDateWithSameDayRange() {
+        // Arrange
+        String accountId = "user_id_1";
+        Date sameDate = new Date();
+        HttpHeaders headers = new HttpHeaders();
+        
+        ArrayList<Order> mockOrders = new ArrayList<>();
+        Order mockOrder = new Order();
+        mockOrder.setAccountId(accountId);
+        mockOrder.setTravelDate("2023-05-05");
+        mockOrders.add(mockOrder);
+        
+        // Mock repository response
+        Mockito.when(orderRepository.findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+            .thenReturn(mockOrders);
+        
+        // Act
+        Response response = orderServiceImpl.queryOrdersByAccountAndTravelDate(accountId, sameDate, sameDate, headers);
+        
+        // Assert
+        Assert.assertNotNull(response);
+        Assert.assertEquals(new Integer(1), response.getStatus());
+        Assert.assertEquals("Query Orders By Account And Travel Date Success", response.getMsg());
+        Assert.assertEquals(mockOrders, response.getData());
+        
+        // Verify repository was called
+        Mockito.verify(orderRepository, times(1)).findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+    
+    @Test
+    public void testQueryOrdersByAccountAndTravelDateWithMultipleOrders() {
+        // Arrange
+        String accountId = "user_id_1";
+        Date startDate = new Date();
+        Date endDate = new Date(startDate.getTime() + 172800000); // 2 days later
+        HttpHeaders headers = new HttpHeaders();
+        
+        ArrayList<Order> mockOrders = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Order mockOrder = new Order();
+            mockOrder.setAccountId(accountId);
+            mockOrder.setTravelDate("2023-05-0" + (i + 1));
+            mockOrders.add(mockOrder);
+        }
+        
+        // Mock repository response
+        Mockito.when(orderRepository.findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+            .thenReturn(mockOrders);
+        
+        // Act
+        Response response = orderServiceImpl.queryOrdersByAccountAndTravelDate(accountId, startDate, endDate, headers);
+        
+        // Assert
+        Assert.assertNotNull(response);
+        Assert.assertEquals(new Integer(1), response.getStatus());
+        Assert.assertEquals("Query Orders By Account And Travel Date Success", response.getMsg());
+        Assert.assertEquals(5, ((ArrayList<Order>)response.getData()).size());
+        Assert.assertEquals(mockOrders, response.getData());
+        
+        // Verify repository was called
+        Mockito.verify(orderRepository, times(1)).findByAccountIdAndTravelDateBetween(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
 }


### PR DESCRIPTION
**Description:**
Extend the `OrderRepository` and service layer to enable searching for orders using both an `accountId` and a specified `travelDate` range (startDate and endDate). This supports backend reporting and enables user portals to filter orders for a given user within a time window.

 **Acceptance Criteria:**
- Add a new `OrderRepository` method accepting accountId and date range using proper Date types for accurate date comparison
- The `OrderService` provides a public method for this query with input validation
- The OrderController adds a POST endpoint /api/v1/orderservice/order/byDate (not GET) that consumes `OrderByAccountAndDateRangeInfo` as the JSON request body
- Implement proper date handling to ensure accurate date range queries
- Include appropriate error handling and input validation
- Maintain consistency with existing code patterns and HTTP standards
- Ensure comprehensive test coverage including edge cases and error scenarios