### PR TITLE
Payments and Assurance:  Implement Payment Search by User and Date Range

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "8",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "ts-payment-service:com.trainticket.controller.PaymentControllerIntegrationTest",
+      "ts-payment-service:com.trainticket.controller.PaymentControllerTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/ts-common/src/main/java/edu/fudan/common/util/Response.java
+++ b/ts-common/src/main/java/edu/fudan/common/util/Response.java
@@ -5,6 +5,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.util.Objects;
+
 /**
  * @author fdse
  */
@@ -21,4 +23,19 @@ public class Response<T> {
 
     String msg;
     T data;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Response<?> response = (Response<?>) o;
+        return Objects.equals(status, response.status) &&
+               Objects.equals(msg, response.msg) &&
+               Objects.equals(data, response.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status, msg, data);
+    }
 }

--- a/ts-payment-service/src/main/java/com/trainticket/controller/PaymentController.java
+++ b/ts-payment-service/src/main/java/com/trainticket/controller/PaymentController.java
@@ -2,12 +2,16 @@ package com.trainticket.controller;
 
 import com.trainticket.entity.Payment;
 import com.trainticket.service.PaymentService;
+import edu.fudan.common.util.Response;
+import io.swagger.annotations.ApiParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
+
+import org.springframework.http.ResponseEntity;
 
 import static org.springframework.http.ResponseEntity.ok;
 
@@ -46,4 +50,27 @@ public class PaymentController {
         PaymentController.LOGGER.info("[query][Query payment]");
         return ok(service.query(headers));
     }
+
+    @GetMapping(path = "/payment/search", produces = "application/json")
+    public HttpEntity search(
+            @ApiParam(value = "User ID for filtering payments. Required non-empty string identifying the user whose payment history to retrieve.", required = true, example = "user123") 
+            @RequestParam("userId") String userId,
+            @ApiParam(value = "Start date of the search range in yyyy-MM-dd format. Payments from start of this day (00:00:00 UTC) will be included.", required = true, example = "2025-01-01") 
+            @RequestParam("startDate") String startDate,
+            @ApiParam(value = "End date of the search range in yyyy-MM-dd format. Payments until end of this day (23:59:59 UTC) will be included. Must be on or after startDate.", required = true, example = "2025-01-31") 
+            @RequestParam("endDate") String endDate,
+            @ApiParam(value = "Page number for pagination (0-based index). Use 0 for first page. Must be non-negative.", example = "0") 
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @ApiParam(value = "Number of records per page. Must be between 1 and configured max page size (default 1000). Results are sorted by payment time in descending order (most recent first).", example = "10") 
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestHeader HttpHeaders headers
+    ) {
+        LOGGER.info("[search][Query payments by user and date range][userId: {}, startDate: {}, endDate: {}, page: {}, size: {}]", userId, startDate, endDate, page, size);
+        Response<?> resp = service.searchByUserAndDateRange(userId, startDate, endDate, page, size, headers);
+        if (resp.getStatus() == 0) {
+            return ResponseEntity.badRequest().body(resp);
+        }
+        return ok(resp);
+    }
+
 }

--- a/ts-payment-service/src/main/java/com/trainticket/entity/Money.java
+++ b/ts-payment-service/src/main/java/com/trainticket/entity/Money.java
@@ -29,4 +29,28 @@ public class Money {
     private String userId;
     private String money; //NOSONAR
 
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getMoney() {
+        return money;
+    }
+
+    public void setMoney(String money) {
+        this.money = money;
+    }
+
 }

--- a/ts-payment-service/src/main/java/com/trainticket/entity/Payment.java
+++ b/ts-payment-service/src/main/java/com/trainticket/entity/Payment.java
@@ -7,8 +7,11 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -16,6 +19,9 @@ import java.util.UUID;
  */
 @Data
 @Entity
+@Table(indexes = {
+    @Index(name = "idx_payment_user_time", columnList = "userId, payment_time")
+})
 @GenericGenerator(name = "jpa-uuid", strategy = "org.hibernate.id.UUIDGenerator")
 public class Payment {
     @Id
@@ -39,11 +45,55 @@ public class Payment {
     @Column(name = "payment_price")
     private String price;
 
+    @Column(name = "payment_time")
+    private Instant paymentTime;
+
     public Payment(){
         this.id = UUID.randomUUID().toString();
         this.orderId = "";
         this.userId = "";
         this.price = "";
+        this.paymentTime = null;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(String orderId) {
+        this.orderId = orderId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public Instant getPaymentTime() {
+        return paymentTime;
+    }
+
+    public void setPaymentTime(Instant paymentTime) {
+        this.paymentTime = paymentTime;
     }
 
 }

--- a/ts-payment-service/src/main/java/com/trainticket/repository/PaymentRepository.java
+++ b/ts-payment-service/src/main/java/com/trainticket/repository/PaymentRepository.java
@@ -1,15 +1,18 @@
 package com.trainticket.repository;
 
 import com.trainticket.entity.Payment;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
 /**
  * @author fdse
  */
-public interface PaymentRepository extends CrudRepository<Payment,String> {
+public interface PaymentRepository extends PagingAndSortingRepository<Payment,String> {
 
     Optional<Payment> findById(String id);
 
@@ -19,4 +22,6 @@ public interface PaymentRepository extends CrudRepository<Payment,String> {
     List<Payment> findAll();
 
     List<Payment> findByUserId(String userId);
+
+    Page<Payment> findByUserIdAndPaymentTimeBetween(String userId, Instant start, Instant end, Pageable pageable);
 }

--- a/ts-payment-service/src/main/java/com/trainticket/service/PaymentService.java
+++ b/ts-payment-service/src/main/java/com/trainticket/service/PaymentService.java
@@ -4,6 +4,8 @@ import com.trainticket.entity.Payment;
 import edu.fudan.common.util.Response;
 import org.springframework.http.HttpHeaders;
 
+import java.time.Instant;
+
 /**
  * @author Chenjie
  * @date 2017/4/3
@@ -15,6 +17,8 @@ public interface PaymentService {
     Response addMoney(Payment info, HttpHeaders headers);
 
     Response query(HttpHeaders headers);
+
+    Response searchByUserAndDateRange(String userId, String start, String end, int page, int size, HttpHeaders headers);
 
     void initPayment(Payment payment,HttpHeaders headers);
 

--- a/ts-payment-service/src/main/resources/application.yml
+++ b/ts-payment-service/src/main/resources/application.yml
@@ -25,3 +25,7 @@ spring:
 
 swagger:
   controllerPackage: com.trainticket.controller
+
+payment:
+  search:
+    max-page-size: 1000

--- a/ts-payment-service/src/test/java/com/trainticket/controller/PaymentControllerIntegrationTest.java
+++ b/ts-payment-service/src/test/java/com/trainticket/controller/PaymentControllerIntegrationTest.java
@@ -1,0 +1,162 @@
+package com.trainticket.controller;
+
+import com.alibaba.fastjson.JSONObject;
+import com.trainticket.entity.Payment;
+import com.trainticket.repository.PaymentRepository;
+import edu.fudan.common.util.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class PaymentControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    PaymentRepository paymentRepository;
+
+
+    @AfterEach
+    void setUp() {
+        paymentRepository.deleteAll();
+    }
+
+    @Test
+    void searchSuccess() throws Exception {
+        // given
+        String orderId = "ORD-INTEG-1";
+        String userId  = "user-integ";
+        savePayment("PAY-DB-1", orderId, userId,
+                Instant.parse("2025-01-01T12:34:56Z"));
+
+        // when
+        String raw = doSearch(userId, "2025-01-01", "2025-12-31", 0, 10);
+
+        // then
+        Response<?> resp = JSONObject.parseObject(raw, Response.class);
+        Assertions.assertEquals(1, resp.getStatus(), "service must report success");
+        Assertions.assertTrue(raw.contains(orderId),
+                "response body should contain the created orderId");
+    }
+
+    @Test
+    void searchFailedByRange() throws Exception {
+        // given
+        String orderId = "ORD-INTEG-1";
+        String userId  = "user-integ";
+        savePayment("PAY-DB-1", orderId, userId,
+                Instant.parse("2025-01-01T12:34:56Z"));
+
+        // when
+        String raw = doSearch(userId, "2024-01-01", "2024-12-31", 0, 10);
+
+        // then
+        Response<?> resp = JSONObject.parseObject(raw, Response.class);
+        Assertions.assertEquals(1, resp.getStatus(), "service must report success");
+        Assertions.assertFalse(raw.contains(orderId),
+                "response body should not contain the created orderId");
+    }
+
+    @Test
+    void searchBlankUserId() throws Exception {
+        mockMvc.perform(
+                        get("/api/v1/paymentservice/payment/search")
+                                .param("userId", "   ")
+                                .param("startDate", "2025-01-01")
+                                .param("endDate", "2025-01-31")
+                                .header("X-Request-Id", "test-request")
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(0))
+                .andExpect(jsonPath("$.msg").value("userId must not be blank"));
+    }
+
+    @Test
+    void searchInvalidDate() throws Exception {
+        mockMvc.perform(
+                        get("/api/v1/paymentservice/payment/search")
+                                .param("userId", "u1")
+                                .param("startDate", "invalid-date")
+                                .param("endDate", "2025-01-31")
+                                .header("X-Request-Id", "test-request")
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(0))
+                .andExpect(jsonPath("$.msg").value("startDate must be in yyyy-MM-dd format (e.g., 2025-01-15)"));
+    }
+
+    @Test
+    void searchEndBeforeStart() throws Exception {
+        mockMvc.perform(
+                        get("/api/v1/paymentservice/payment/search")
+                                .param("userId", "u1")
+                                .param("startDate", "2025-02-01")
+                                .param("endDate", "2025-01-01")
+                                .header("X-Request-Id", "test-request")
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(0))
+                .andExpect(jsonPath("$.msg").value("endDate must be on or after startDate"));
+    }
+
+    /**
+     * Persists a {@link Payment} instance that will later be queried.
+     */
+    private void savePayment(String paymentId,
+                             String orderId,
+                             String userId,
+                             Instant paymentTime) {
+
+        Payment payment = new Payment();
+        payment.setId(paymentId);
+        payment.setOrderId(orderId);
+        payment.setUserId(userId);
+        payment.setPrice("50");
+        payment.setPaymentTime(paymentTime);
+        paymentRepository.save(payment);
+    }
+
+    /**
+     * Invokes the search endpoint and returns the raw JSON response body.
+     */
+    private String doSearch(String userId,
+                            String startDate,
+                            String endDate,
+                            int page,
+                            int size) throws Exception {
+
+        return mockMvc.perform(get("/api/v1/paymentservice/payment/search")
+                        .param("userId",   userId)
+                        .param("startDate", startDate)
+                        .param("endDate",   endDate)
+                        .param("page",      String.valueOf(page))
+                        .param("size",      String.valueOf(size))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(1))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+    }
+
+
+}

--- a/ts-payment-service/src/test/java/com/trainticket/controller/PaymentControllerTest.java
+++ b/ts-payment-service/src/test/java/com/trainticket/controller/PaymentControllerTest.java
@@ -34,6 +34,9 @@ public class PaymentControllerTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         mockMvc = MockMvcBuilders.standaloneSetup(paymentController).build();
+        response.setStatus(1);
+        response.setMsg("Success");
+        response.setData(null);
     }
 
     @Test
@@ -51,7 +54,10 @@ public class PaymentControllerTest {
         String result = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/paymentservice/payment").contentType(MediaType.APPLICATION_JSON).content(requestJson))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals(response, JSONObject.parseObject(result, Response.class));
+        Response parsedResponse = JSONObject.parseObject(result, Response.class);
+        Assert.assertEquals(response.getStatus(), parsedResponse.getStatus());
+        Assert.assertEquals(response.getMsg(), parsedResponse.getMsg());
+        Assert.assertEquals(response.getData(), parsedResponse.getData());
     }
 
     @Test
@@ -62,7 +68,10 @@ public class PaymentControllerTest {
         String result = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/paymentservice/payment/money").contentType(MediaType.APPLICATION_JSON).content(requestJson))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals(response, JSONObject.parseObject(result, Response.class));
+        Response parsedResponse = JSONObject.parseObject(result, Response.class);
+        Assert.assertEquals(response.getStatus(), parsedResponse.getStatus());
+        Assert.assertEquals(response.getMsg(), parsedResponse.getMsg());
+        Assert.assertEquals(response.getData(), parsedResponse.getData());
     }
 
     @Test
@@ -71,7 +80,43 @@ public class PaymentControllerTest {
         String result = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/paymentservice/payment"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals(response, JSONObject.parseObject(result, Response.class));
+        Response parsedResponse = JSONObject.parseObject(result, Response.class);
+        Assert.assertEquals(response.getStatus(), parsedResponse.getStatus());
+        Assert.assertEquals(response.getMsg(), parsedResponse.getMsg());
+        Assert.assertEquals(response.getData(), parsedResponse.getData());
+    }
+
+    @Test
+    public void testSearch() throws Exception {
+        Mockito.when(
+                service.searchByUserAndDateRange(
+                        Mockito.anyString(),   // userId
+                        Mockito.anyString(),   // startDate
+                        Mockito.anyString(),   // endDate
+                        Mockito.anyInt(),      // page
+                        Mockito.anyInt(),      // size
+                        Mockito.any(HttpHeaders.class)
+                )
+        ).thenReturn(response);
+
+        String result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/v1/paymentservice/payment/search")
+                                .param("userId", "testUser")
+                                .param("startDate", "2025-01-01")
+                                .param("endDate", "2025-01-31")
+                                .param("page", "0")
+                                .param("size", "10")
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        Response parsedResponse = JSONObject.parseObject(result, Response.class);
+        Assert.assertEquals(response.getStatus(), parsedResponse.getStatus());
+        Assert.assertEquals(response.getMsg(), parsedResponse.getMsg());
+        Assert.assertEquals(response.getData(), parsedResponse.getData());
     }
 
 }

--- a/ts-payment-service/src/test/java/com/trainticket/service/PaymentServiceImplTest.java
+++ b/ts-payment-service/src/test/java/com/trainticket/service/PaymentServiceImplTest.java
@@ -14,8 +14,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,6 +41,7 @@ public class PaymentServiceImplTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+        ReflectionTestUtils.setField(paymentServiceImpl, "maxPageSize", 1000);
     }
 
     @Test
@@ -44,7 +50,9 @@ public class PaymentServiceImplTest {
         Mockito.when(paymentRepository.findByOrderId(Mockito.anyString())).thenReturn(null);
         Mockito.when(paymentRepository.save(Mockito.any(Payment.class))).thenReturn(null);
         Response result = paymentServiceImpl.pay(info, headers);
-        Assert.assertEquals(new Response<>(1, "Pay Success", null), result);
+        Assert.assertEquals(1, result.getStatus().intValue());
+        Assert.assertEquals("Pay Success", result.getMsg());
+        Assert.assertNull(result.getData());
     }
 
     @Test
@@ -52,15 +60,20 @@ public class PaymentServiceImplTest {
         Payment info = new Payment();
         Mockito.when(paymentRepository.findByOrderId(Mockito.anyString())).thenReturn(info);
         Response result = paymentServiceImpl.pay(info, headers);
-        Assert.assertEquals(new Response<>(0, "Pay Failed, order not found with order id", null), result);
+        Assert.assertEquals(0, result.getStatus().intValue());
+        Assert.assertTrue(result.getMsg().startsWith("Pay Failed, order not found with order id"));
+        Assert.assertNull(result.getData());
     }
 
     @Test
     public void testAddMoney() {
         Payment info = new Payment();
-        Mockito.when(addMoneyRepository.save(Mockito.any(Money.class))).thenReturn(null);
+        Money savedMoney = new Money();
+        Mockito.when(addMoneyRepository.save(Mockito.any(Money.class))).thenReturn(savedMoney);
         Response result = paymentServiceImpl.addMoney(info, headers);
-        Assert.assertEquals(new Response<>(1,"Add Money Success", null), result);
+        Assert.assertEquals(1, result.getStatus().intValue());
+        Assert.assertEquals("Add Money Success", result.getMsg());
+        Assert.assertNotNull(result.getData());
     }
 
     @Test
@@ -69,20 +82,24 @@ public class PaymentServiceImplTest {
         payments.add(new Payment());
         Mockito.when(paymentRepository.findAll()).thenReturn(payments);
         Response result = paymentServiceImpl.query(headers);
-        Assert.assertEquals(new Response<>(1,"Query Success",  payments), result);
+        Assert.assertEquals(1, result.getStatus().intValue());
+        Assert.assertEquals("Query Success", result.getMsg());
+        Assert.assertEquals(payments, result.getData());
     }
 
     @Test
     public void testQuery2() {
         Mockito.when(paymentRepository.findAll()).thenReturn(null);
         Response result = paymentServiceImpl.query(headers);
-        Assert.assertEquals(new Response<>(0, "No Content", null), result);
+        Assert.assertEquals(0, result.getStatus().intValue());
+        Assert.assertEquals("No Content", result.getMsg());
+        Assert.assertNull(result.getData());
     }
 
     @Test
     public void testInitPayment1() {
         Payment payment = new Payment();
-        Mockito.when(paymentRepository.findById(Mockito.anyString())).thenReturn(null);
+        Mockito.when(paymentRepository.findById(Mockito.anyString())).thenReturn(java.util.Optional.empty());
         Mockito.when(paymentRepository.save(Mockito.any(Payment.class))).thenReturn(null);
         paymentServiceImpl.initPayment(payment, headers);
         Mockito.verify(paymentRepository, Mockito.times(1)).save(Mockito.any(Payment.class));
@@ -95,6 +112,130 @@ public class PaymentServiceImplTest {
         Mockito.when(paymentRepository.save(Mockito.any(Payment.class))).thenReturn(null);
         paymentServiceImpl.initPayment(payment, headers);
         Mockito.verify(paymentRepository, Mockito.times(0)).save(Mockito.any(Payment.class));
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_Success() {
+        List<Payment> payments = new ArrayList<>();
+        Payment payment = new Payment();
+        payment.setUserId("user123");
+        payments.add(payment);
+        Page<Payment> pagedPayments = new PageImpl<>(payments);
+        
+        Mockito.when(paymentRepository.findByUserIdAndPaymentTimeBetween(
+            Mockito.eq("user123"), 
+            Mockito.any(Instant.class), 
+            Mockito.any(Instant.class), 
+            Mockito.any(Pageable.class)
+        )).thenReturn(pagedPayments);
+        
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "2025-01-01", "2025-01-31", 0, 10, headers);
+        Assert.assertEquals(Integer.valueOf(1), result.getStatus());
+        Assert.assertEquals("Query Success", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_BlankUserId() {
+        Response result = paymentServiceImpl.searchByUserAndDateRange("", "2025-01-01", "2025-01-31", 0, 10, headers);
+        Assert.assertEquals(Integer.valueOf(0), result.getStatus());
+        Assert.assertEquals("userId must not be blank", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_NullUserId() {
+        Response result = paymentServiceImpl.searchByUserAndDateRange(null, "2025-01-01", "2025-01-31", 0, 10, headers);
+        Assert.assertEquals(Integer.valueOf(0), result.getStatus());
+        Assert.assertEquals("userId must not be blank", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_BlankStartDate() {
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "", "2025-01-31", 0, 10, headers);
+        Assert.assertEquals(Integer.valueOf(0), result.getStatus());
+        Assert.assertEquals("startDate must not be blank and must be in yyyy-MM-dd format", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_InvalidStartDateFormat() {
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "2025/01/01", "2025-01-31", 0, 10, headers);
+        Assert.assertEquals(Integer.valueOf(0), result.getStatus());
+        Assert.assertEquals("startDate must be in yyyy-MM-dd format (e.g., 2025-01-15)", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_BlankEndDate() {
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "2025-01-01", "", 0, 10, headers);
+        Assert.assertEquals(Integer.valueOf(0), result.getStatus());
+        Assert.assertEquals("endDate must not be blank and must be in yyyy-MM-dd format", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_InvalidEndDateFormat() {
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "2025-01-01", "01-31-2025", 0, 10, headers);
+        Assert.assertEquals(Integer.valueOf(0), result.getStatus());
+        Assert.assertEquals("endDate must be in yyyy-MM-dd format (e.g., 2025-01-31)", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_EndBeforeStart() {
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "2025-01-31", "2025-01-01", 0, 10, headers);
+        Assert.assertEquals(Integer.valueOf(0), result.getStatus());
+        Assert.assertEquals("endDate must be on or after startDate", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_NegativePage() {
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "2025-01-01", "2025-01-31", -1, 10, headers);
+        Assert.assertEquals(Integer.valueOf(0), result.getStatus());
+        Assert.assertEquals("page must be >= 0", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_ZeroSize() {
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "2025-01-01", "2025-01-31", 0, 0, headers);
+        Assert.assertEquals(Integer.valueOf(0), result.getStatus());
+        Assert.assertEquals("size must be between 1 and 1000", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_ExceedsMaxSize() {
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "2025-01-01", "2025-01-31", 0, 1001, headers);
+        Assert.assertEquals(Integer.valueOf(0), result.getStatus());
+        Assert.assertEquals("size must be between 1 and 1000", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_SameDateRange() {
+        List<Payment> payments = new ArrayList<>();
+        Page<Payment> pagedPayments = new PageImpl<>(payments);
+        
+        Mockito.when(paymentRepository.findByUserIdAndPaymentTimeBetween(
+            Mockito.eq("user123"), 
+            Mockito.any(Instant.class), 
+            Mockito.any(Instant.class), 
+            Mockito.any(Pageable.class)
+        )).thenReturn(pagedPayments);
+        
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "2025-01-15", "2025-01-15", 0, 10, headers);
+        Assert.assertEquals(Integer.valueOf(1), result.getStatus());
+        Assert.assertEquals("Query Success", result.getMsg());
+    }
+
+    @Test
+    public void testSearchByUserAndDateRange_MaxSize() {
+        List<Payment> payments = new ArrayList<>();
+        Page<Payment> pagedPayments = new PageImpl<>(payments);
+        
+        Mockito.when(paymentRepository.findByUserIdAndPaymentTimeBetween(
+            Mockito.eq("user123"), 
+            Mockito.any(Instant.class), 
+            Mockito.any(Instant.class), 
+            Mockito.any(Pageable.class)
+        )).thenReturn(pagedPayments);
+        
+        Response result = paymentServiceImpl.searchByUserAndDateRange("user123", "2025-01-01", "2025-01-31", 0, 1000, headers);
+        Assert.assertEquals(Integer.valueOf(1), result.getStatus());
+        Assert.assertEquals("Query Success", result.getMsg());
     }
 
 }

--- a/ts-payment-service/src/test/resources/application-test.yml
+++ b/ts-payment-service/src/test/resources/application-test.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: ts-payment-service
+  cloud:
+    nacos:
+      discovery:
+        enabled: false
+  datasource:
+    url: jdbc:h2:mem:paymentdb;DB_CLOSE_DELAY=-1;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+server:
+  port: 0


### PR DESCRIPTION
**Description:**
Extend the `PaymentRepository` in the `ts-payment-service` to support querying payments by `userId` and a provided payment date range. This enables support for user billing statements and financial auditing.
**Acceptance Criteria:**
- Add a JPA method to `PaymentRepository` that accepts `userId`, `startDate`, and `endDate`.
- Expose the query via a REST endpoint in `PaymentController`, accepting pagination parameters.
    - HTTP method: GET
    - Path: /payment/search
    - Query parameters
        - userId, 
        - startDate (yyyy-MM-dd)
        - endDate (yyyy-MM-dd)
        - page (int, optional) – 0-based page index
        - size (int, optional) – page size
- Results return only payments matching criteria, paginated, and input validation is performed.
