### PR TITLE
Payments and Assurance: Document Payment Service APIs with OpenAPI/Swagger

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,11 @@
   "jvm_version": "8",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "ts-payment-service:com.trainticket.SwaggerIntegrationTest#mediaTypesAreSpecified",
+      "ts-payment-service:com.trainticket.SwaggerIntegrationTest#methodsAreAnnotatedApiOperationAnnotation",
+      "ts-payment-service:com.trainticket.SwaggerIntegrationTest#everyPaymentServiceOperationHasDescription"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/ts-common/src/main/java/edu/fudan/common/util/Response.java
+++ b/ts-common/src/main/java/edu/fudan/common/util/Response.java
@@ -1,5 +1,7 @@
 package edu.fudan.common.util;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,13 +14,17 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
+@ApiModel(description = "Standard response envelope")
 public class Response<T> {
-
     /**
      * 1 true, 0 false
      */
+    @ApiModelProperty(value = "1 = success, 0 = failure", example = "1")
     Integer status;
 
+    @ApiModelProperty(value = "Human-readable message", example = "SUCCESS")
     String msg;
+
+    @ApiModelProperty(value = "Payload returned by the endpoint")
     T data;
 }

--- a/ts-payment-service/src/main/java/com/trainticket/controller/PaymentController.java
+++ b/ts-payment-service/src/main/java/com/trainticket/controller/PaymentController.java
@@ -2,6 +2,8 @@ package com.trainticket.controller;
 
 import com.trainticket.entity.Payment;
 import com.trainticket.service.PaymentService;
+import edu.fudan.common.util.Response;
+import io.swagger.annotations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,24 +26,59 @@ public class PaymentController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PaymentController.class);
 
-    @GetMapping(path = "/welcome")
+    @ApiOperation(
+            value = "Service welcome / health-check",
+            notes = "Returns plain text used by load-balancers or monitoring tools to verify the service is alive."
+    )
+    @ApiResponses(@ApiResponse(code = 200, message = "Plain text welcome message",
+            response = String.class))
+    @GetMapping(path = "/welcome", produces = "text/plain")
     public String home() {
         return "Welcome to [ Payment Service ] !";
     }
 
-    @PostMapping(path = "/payment")
-    public HttpEntity pay(@RequestBody Payment info, @RequestHeader HttpHeaders headers) {
+    @ApiOperation(
+            value = "Pay for an order",
+            notes = "Debits the user’s balance and persists the payment record."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Payment successfully processed",
+                    response = Response.class)
+    })
+    @PostMapping(path = "/payment", consumes = "application/json", produces = "application/json")
+    public HttpEntity pay(
+            @ApiParam(value = "Payment payload", required = true) @RequestBody Payment info,
+            @RequestHeader HttpHeaders headers) {
         PaymentController.LOGGER.info("[pay][Pay][PaymentId: {}]", info.getId());
         return ok(service.pay(info, headers));
     }
 
-    @PostMapping(path = "/payment/money")
-    public HttpEntity addMoney(@RequestBody Payment info, @RequestHeader HttpHeaders headers) {
+    @ApiOperation(
+            value = "Add money to the user account",
+            notes = "Credits the user’s balance."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Money added successfully",
+                    response = Response.class)
+    })
+    @PostMapping(path = "/payment/money", consumes = "application/json", produces = "application/json")
+    public HttpEntity addMoney(
+            @ApiParam(value = "Top-up payload", required = true) @RequestBody Payment info,
+            @RequestHeader HttpHeaders headers) {
+
         PaymentController.LOGGER.info("[addMoney][Add money][PaymentId: {}]", info.getId());
         return ok(service.addMoney(info, headers));
     }
 
-    @GetMapping(path = "/payment")
+    @ApiOperation(
+            value = "Query payments",
+            notes = "Returns a list of payment records for the current user."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "List of payments",
+                    response = Response.class, responseContainer = "List")
+    })
+    @GetMapping(path = "/payment", produces = "application/json")
     public HttpEntity query(@RequestHeader HttpHeaders headers) {
         PaymentController.LOGGER.info("[query][Query payment]");
         return ok(service.query(headers));

--- a/ts-payment-service/src/test/java/com/trainticket/SwaggerIntegrationTest.java
+++ b/ts-payment-service/src/test/java/com/trainticket/SwaggerIntegrationTest.java
@@ -1,0 +1,177 @@
+package com.trainticket;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.controller.PaymentController;
+import com.trainticket.entity.Payment;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponses;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class SwaggerIntegrationTest {
+    private static final String API_DOCS_PATH = "/v2/api-docs";
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void swaggerUiShouldBeAccessible() {
+        // given
+        String url = "http://127.0.0.1:" + port + "/swagger-ui.html";
+
+        // when
+        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+        // then
+        HttpStatus status = response.getStatusCode();
+        boolean accessible = status.is2xxSuccessful() || status.is3xxRedirection();
+
+        assertTrue("Expected HTTP 2xx/3xx from " + url + " but got " + status, accessible);
+
+        // Optional – verify that the body (or redirect target) looks like Swagger UI
+        if (status.is2xxSuccessful()) {
+            assertTrue(
+                    "Response body does not contain the expected Swagger keyword",
+                    response.getBody() != null &&
+                            response.getBody().toLowerCase().contains("swagger"));
+        }
+    }
+
+    @Test
+    public void mediaTypesAreSpecified() throws Exception {
+
+        // 1. Download the Swagger/OpenAPI JSON
+        JsonNode root = retrieveGeneratedDoc();
+        JsonNode paths = root.path("paths");
+        assertFalse("No 'paths' node found in Swagger JSON", paths.isMissingNode());
+
+        assertMediaType(paths,
+                "/api/v1/paymentservice/welcome",
+                "get",
+                "text/plain");
+
+        assertMediaType(paths,
+                "/api/v1/paymentservice/payment",
+                "post",
+                "application/json");
+
+        assertMediaType(paths,
+                "/api/v1/paymentservice/payment/money",
+                "post",
+                "application/json");
+    }
+
+    private JsonNode retrieveGeneratedDoc() throws JsonProcessingException {
+        ResponseEntity<String> response =
+                restTemplate.getForEntity("http://127.0.0.1:" + port + API_DOCS_PATH, String.class);
+
+        assertTrue("Swagger JSON should be returned successfully",
+                response.getStatusCode().is2xxSuccessful());
+
+        // 2. Parse JSON
+        JsonNode root = mapper.readTree(response.getBody());
+        return root;
+    }
+
+    /**
+     * Verifies that the given operation declares the expected media type in its
+     * 'produces' array.
+     */
+    private void assertMediaType(JsonNode paths,
+                                 String endpoint,
+                                 String httpMethod,
+                                 String expectedMediaType) {
+
+        JsonNode producesNode = paths
+                .path(endpoint)
+                .path(httpMethod)
+                .path("produces");
+
+        assertFalse("Missing 'produces' section for " + httpMethod.toUpperCase() + " " + endpoint,
+                producesNode.isMissingNode() || !producesNode.isArray());
+
+        boolean found = false;
+        for (JsonNode node : producesNode) {
+            if (expectedMediaType.equals(node.asText())) {
+                found = true;
+                break;
+            }
+        }
+
+        assertTrue("Media type '" + expectedMediaType + "' not specified for "
+                        + httpMethod.toUpperCase() + " " + endpoint,
+                found);
+    }
+
+    @Test
+    public void methodsAreAnnotatedApiOperationAnnotation() throws Exception {
+        checkAnnotatedWithOpenSpecAnnotations(PaymentController.class.getDeclaredMethod("home"));
+        checkAnnotatedWithOpenSpecAnnotations(PaymentController.class.getDeclaredMethod("pay", Payment.class, org.springframework.http.HttpHeaders.class));
+        checkAnnotatedWithOpenSpecAnnotations(PaymentController.class.getDeclaredMethod("addMoney", Payment.class, org.springframework.http.HttpHeaders.class));
+        checkAnnotatedWithOpenSpecAnnotations(PaymentController.class.getDeclaredMethod("query", org.springframework.http.HttpHeaders.class));
+    }
+
+    private static void checkAnnotatedWithOpenSpecAnnotations(Method m) throws NoSuchMethodException {
+
+        assertTrue(m.isAnnotationPresent(ApiOperation.class));
+        assertTrue(m.isAnnotationPresent(ApiResponses.class));
+    }
+
+    @Test
+    public void everyPaymentServiceOperationHasDescription() throws JsonProcessingException {
+        JsonNode root = retrieveGeneratedDoc();
+        JsonNode paths = root.path("paths");
+
+        // Iterate over all documented paths
+        Iterator<String> pathIt = paths.fieldNames();
+        while (pathIt.hasNext()) {
+            String path = pathIt.next();
+
+            // Only look at Payment-service endpoints
+            if (!path.startsWith("/api/v1/paymentservice")) {
+                continue;
+            }
+
+            JsonNode operations = paths.get(path);
+            Iterator<String> methodIt = operations.fieldNames();
+            while (methodIt.hasNext()) {
+                String httpMethod = methodIt.next();
+                JsonNode operation = operations.get(httpMethod);
+
+                JsonNode descriptionNode = operation.get("description");
+                assertThat(descriptionNode)
+                        .withFailMessage("Missing description for %s %s",
+                                httpMethod.toUpperCase(), path)
+                        .isNotNull();
+
+                assertThat(descriptionNode.asText())
+                        .withFailMessage("Blank description for %s %s",
+                                httpMethod.toUpperCase(), path)
+                        .isNotBlank();
+            }
+        }
+    }
+}

--- a/ts-payment-service/src/test/resources/application.yml
+++ b/ts-payment-service/src/test/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: ts-payment-service-test
+  datasource:
+    url: jdbc:h2:mem:payment_test;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+  cloud:
+    nacos:
+      discovery:
+        register-enabled: false
+        enabled: false
+
+server:
+  port: 0


### PR DESCRIPTION
**Description:**
Add OpenAPI annotations to all public endpoints in `PaymentController`, generating an up-to-date Swagger spec. 
**Acceptance Criteria:**
- All endpoints have OpenAPI annotations -  `@ApiOperation`, `@ApiResponses`;
- `/swagger-ui.html` exposes documented API;
- Docs include produced media type for each endpoint;
- Docs include description for each endpoint.