### PR TITLE
Payments and Assurance:   Implement Paginated API for Assurance Claims

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "8",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "ts-assurance-service:assurance.service.AssuranceServiceImplTest",
+      "ts-assurance-service:assurance.controller.AssuranceControllerTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/ts-assurance-service/src/main/java/assurance/controller/AssuranceController.java
+++ b/ts-assurance-service/src/main/java/assurance/controller/AssuranceController.java
@@ -1,11 +1,13 @@
 package assurance.controller;
 
 import assurance.service.AssuranceService;
+import edu.fudan.common.util.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -34,6 +36,28 @@ public class AssuranceController {
     public HttpEntity getAllAssurances(@RequestHeader HttpHeaders headers) {
         AssuranceController.LOGGER.info("[getAllAssurances][Get All Assurances]");
         return ok(assuranceService.getAllAssurances(headers));
+    }
+
+
+    @CrossOrigin(origins = "*")
+    @GetMapping(path = "/assurances/userid/{userId}")
+    public HttpEntity getUserAssurances(@PathVariable String userId,
+                                       @RequestParam(value = "page", required = false) Integer page,
+                                       @RequestParam(value = "size", required = false) Integer size,
+                                       @RequestHeader HttpHeaders headers) {
+        // UUID Validation
+        UUID userUUID;
+        try {
+            userUUID = UUID.fromString(userId);
+        } catch (IllegalArgumentException e) {
+            AssuranceController.LOGGER.error("[getUserAssurances][Invalid UUID: {}]", userId);
+            // Return Response wrapper with 400 status
+            return ResponseEntity.badRequest()
+                .body(new Response<>(0, "Invalid UUID format", null));
+        }
+        
+        AssuranceController.LOGGER.info("[getUserAssurances][Get User's Assurances][page: {}, size: {}]", page, size);
+        return ok(assuranceService.getUserAssurancesPage(userUUID, page, size, headers));
     }
 
     @CrossOrigin(origins = "*")

--- a/ts-assurance-service/src/main/java/assurance/repository/AssuranceRepository.java
+++ b/ts-assurance-service/src/main/java/assurance/repository/AssuranceRepository.java
@@ -1,7 +1,7 @@
 package assurance.repository;
 
 import assurance.entity.Assurance;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
@@ -12,7 +12,7 @@ import java.util.Optional;
  * @author fdse
  */
 @Repository
-public interface AssuranceRepository  extends CrudRepository<Assurance, String> {
+public interface AssuranceRepository  extends PagingAndSortingRepository<Assurance, String> {
 
     /**
      * find by id

--- a/ts-assurance-service/src/main/java/assurance/service/AssuranceService.java
+++ b/ts-assurance-service/src/main/java/assurance/service/AssuranceService.java
@@ -1,6 +1,8 @@
 package assurance.service;
 
+import assurance.entity.PlainAssurance;
 import edu.fudan.common.util.Response;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
 
 import javax.transaction.Transactional;
@@ -77,6 +79,17 @@ public interface AssuranceService {
      * @return Response
      */
     Response getAllAssurances(HttpHeaders headers);
+
+    /**
+     * get assurances for a user with pagination
+     *
+     * @param userId user id
+     * @param page page number (0-indexed, defaults to 0)
+     * @param size page size (defaults to 10)
+     * @param headers headers
+     * @return Response containing Page<PlainAssurance>
+     */
+    Response getUserAssurancesPage(UUID userId, Integer page, Integer size, HttpHeaders headers);
 
     /**
      * get all assurance types


### PR DESCRIPTION
**Description:**
Add pagination to the endpoint in `ts-assurance-service` listing all assurance claims for a user. The controller must accept page/size params and return paginated results using Spring Data’s Page interface.
**Acceptance Criteria:**
- Endpoint accepts pagination params.
- Results are returned in `Page` format.
- Test covers boundary conditions.