### PR TITLE
Route, Train and Station Management: Create DTO Mapper Utility for RouteDTO

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "8",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "ts-route-service:route.mapper.RouteMapperTest",
+      "ts-route-service:route.service.RouteServiceImplTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/ts-route-service/pom.xml
+++ b/ts-route-service/pom.xml
@@ -21,6 +21,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
+        <org.mapstruct.version>1.5.0.Final</org.mapstruct.version>
     </properties>
 
     <dependencies>
@@ -37,12 +38,41 @@
             <artifactId>ts-common</artifactId>
             <version>0.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${org.mapstruct.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/ts-route-service/src/main/java/route/mapper/RouteDTO.java
+++ b/ts-route-service/src/main/java/route/mapper/RouteDTO.java
@@ -1,0 +1,32 @@
+package route.mapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RouteDTO {
+    private String id;
+    
+    @NotNull(message = "Stations list cannot be null")
+    @NotEmpty(message = "Stations list cannot be empty")
+    private List<String> stations;
+    
+    @NotNull(message = "Distances list cannot be null")
+    @NotEmpty(message = "Distances list cannot be empty")
+    private List<Integer> distances;
+    
+    @NotNull(message = "Start station cannot be null")
+    @NotEmpty(message = "Start station cannot be empty")
+    private String startStation;
+    
+    @NotNull(message = "End station cannot be null")
+    @NotEmpty(message = "End station cannot be empty")
+    private String endStation;
+}

--- a/ts-route-service/src/main/java/route/mapper/RouteMapper.java
+++ b/ts-route-service/src/main/java/route/mapper/RouteMapper.java
@@ -1,0 +1,45 @@
+package route.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+import route.entity.Route;
+
+import java.util.List;
+
+@Mapper
+public interface RouteMapper {
+    
+    RouteMapper INSTANCE = Mappers.getMapper(RouteMapper.class);
+    
+    /**
+     * Converts Route entity to RouteDTO
+     * @param route Route entity
+     * @return RouteDTO
+     */
+    @Mapping(source = "id", target = "id")
+    @Mapping(source = "stations", target = "stations")
+    @Mapping(source = "distances", target = "distances")
+    @Mapping(source = "startStation", target = "startStation")
+    @Mapping(source = "endStation", target = "endStation")
+    RouteDTO toDto(Route route);
+
+    /**
+     * Converts list of Route entities to list of RouteDTOs
+     * @param routes List of Route entities
+     * @return List of RouteDTOs
+     */
+    List<RouteDTO> toDtoList(List<Route> routes);
+
+    /**
+     * Converts RouteDTO to Route entity
+     * @param routeDto RouteDTO
+     * @return Route entity
+     */
+    @Mapping(source = "id", target = "id")
+    @Mapping(source = "stations", target = "stations")
+    @Mapping(source = "distances", target = "distances")
+    @Mapping(source = "startStation", target = "startStation")
+    @Mapping(source = "endStation", target = "endStation")
+    Route toEntity(RouteDTO routeDto);
+}

--- a/ts-route-service/src/main/java/route/service/RouteServiceImpl.java
+++ b/ts-route-service/src/main/java/route/service/RouteServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import route.entity.Route;
 import route.entity.RouteInfo;
+import route.mapper.RouteDTO;
+import route.mapper.RouteMapper;
 import route.repository.RouteRepository;
 
 import java.util.ArrayList;
@@ -24,6 +26,10 @@ public class RouteServiceImpl implements RouteService {
 
     @Autowired
     private RouteRepository routeRepository;
+    
+    @Autowired
+    private RouteMapper routeMapper;
+    
     private static final Logger LOGGER = LoggerFactory.getLogger(RouteServiceImpl.class);
 
     String success = "Success";
@@ -61,7 +67,8 @@ public class RouteServiceImpl implements RouteService {
         route.setStations(stationList);
         route.setDistances(distanceList);
         routeRepository.save(route);
-        return new Response<>(1, "Save and Modify success", route);
+        RouteDTO routeDTO = routeMapper.toDto(route);
+        return new Response<>(1, "Save and Modify success", routeDTO);
     }
 
     @Override
@@ -84,7 +91,8 @@ public class RouteServiceImpl implements RouteService {
             RouteServiceImpl.LOGGER.error("[getRouteById][Find route error][Route not found][RouteId: {}]",routeId);
             return new Response<>(0, "No content with the routeId", null);
         } else {
-            return new Response<>(1, success, route);
+            RouteDTO routeDTO = routeMapper.toDto(route.get());
+            return new Response<>(1, success, routeDTO);
         }
 
     }
@@ -96,7 +104,8 @@ public class RouteServiceImpl implements RouteService {
             RouteServiceImpl.LOGGER.error("[getRouteById][Find route error][Route not found][RouteIds: {}]",routeIds);
             return new Response<>(0, "No content with the routeIds", null);
         } else {
-            return new Response<>(1, success, routes);
+            List<RouteDTO> routeDTOs = routeMapper.toDtoList(routes);
+            return new Response<>(1, success, routeDTOs);
         }
     }
 
@@ -113,7 +122,8 @@ public class RouteServiceImpl implements RouteService {
             }
         }
         if (!resultList.isEmpty()) {
-            return new Response<>(1, success, resultList);
+            List<RouteDTO> routeDTOs = routeMapper.toDtoList(resultList);
+            return new Response<>(1, success, routeDTOs);
         } else {
             RouteServiceImpl.LOGGER.warn("[getRouteByStartAndEnd][Find by start and terminal warn][Routes not found][startId: {},terminalId: {}]",startId,terminalId);
             return new Response<>(0, "No routes with the startId and terminalId", null);
@@ -124,7 +134,8 @@ public class RouteServiceImpl implements RouteService {
     public Response getAllRoutes(HttpHeaders headers) {
         ArrayList<Route> routes = routeRepository.findAll();
         if (routes != null && !routes.isEmpty()) {
-            return new Response<>(1, success, routes);
+            List<RouteDTO> routeDTOs = routeMapper.toDtoList(routes);
+            return new Response<>(1, success, routeDTOs);
         } else {
             RouteServiceImpl.LOGGER.warn("[getAllRoutes][Find all routes warn][{}]","No Content");
             return new Response<>(0, "No Content", null);

--- a/ts-route-service/src/test/java/route/mapper/RouteMapperTest.java
+++ b/ts-route-service/src/test/java/route/mapper/RouteMapperTest.java
@@ -1,0 +1,148 @@
+package route.mapper;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import route.entity.Route;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {TestRouteMapperConfiguration.class})
+public class RouteMapperTest {
+
+    @Autowired
+    private RouteMapper routeMapper;
+
+    @Test
+    public void testToDtoWithValidRoute() {
+        List<String> stations = Arrays.asList("Station1", "Station2", "Station3");
+        List<Integer> distances = Arrays.asList(10, 20, 30);
+        Route route = new Route("test-id", stations, distances, "Station1", "Station3");
+
+        RouteDTO result = routeMapper.toDto(route);
+
+        Assert.assertNotNull("RouteDTO should not be null", result);
+        Assert.assertEquals("ID should match", "test-id", result.getId());
+        Assert.assertEquals("Stations should match", stations, result.getStations());
+        Assert.assertEquals("Distances should match", distances, result.getDistances());
+        Assert.assertEquals("Start station should match", "Station1", result.getStartStation());
+        Assert.assertEquals("End station should match", "Station3", result.getEndStation());
+    }
+
+    /**
+     * Test toDto method with null Route
+     */
+    @Test
+    public void testToDtoWithNullRoute() {
+        RouteDTO result = routeMapper.toDto(null);
+        Assert.assertNull("RouteDTO should be null when input is null", result);
+    }
+
+    /**
+     * Test toDtoList method with valid routes
+     */
+    @Test
+    public void testToDtoListWithValidRoutes() {
+        List<String> stations1 = Arrays.asList("A", "B");
+        List<Integer> distances1 = Arrays.asList(5, 10);
+        Route route1 = new Route("id1", stations1, distances1, "A", "B");
+
+        List<String> stations2 = Arrays.asList("C", "D");
+        List<Integer> distances2 = Arrays.asList(15, 20);
+        Route route2 = new Route("id2", stations2, distances2, "C", "D");
+
+        List<Route> routes = Arrays.asList(route1, route2);
+
+        List<RouteDTO> result = routeMapper.toDtoList(routes);
+
+        Assert.assertNotNull("RouteDTO list should not be null", result);
+        Assert.assertEquals("List size should match", 2, result.size());
+        
+        RouteDTO dto1 = result.get(0);
+        Assert.assertEquals("First DTO ID should match", "id1", dto1.getId());
+        Assert.assertEquals("First DTO stations should match", stations1, dto1.getStations());
+        Assert.assertEquals("First DTO distances should match", distances1, dto1.getDistances());
+        
+        RouteDTO dto2 = result.get(1);
+        Assert.assertEquals("Second DTO ID should match", "id2", dto2.getId());
+        Assert.assertEquals("Second DTO stations should match", stations2, dto2.getStations());
+        Assert.assertEquals("Second DTO distances should match", distances2, dto2.getDistances());
+    }
+
+    /**
+     * Test toDtoList method with null list
+     */
+    @Test
+    public void testToDtoListWithNullList() {
+        List<RouteDTO> result = routeMapper.toDtoList(null);
+        Assert.assertNull("RouteDTO list should be null when input is null", result);
+    }
+
+    /**
+     * Test toDtoList method with empty list
+     */
+    @Test
+    public void testToDtoListWithEmptyList() {
+        List<Route> routes = new ArrayList<>();
+        List<RouteDTO> result = routeMapper.toDtoList(routes);
+        
+        Assert.assertNotNull("RouteDTO list should not be null", result);
+        Assert.assertTrue("RouteDTO list should be empty", result.isEmpty());
+    }
+
+    /**
+     * Test toEntity method with valid DTO
+     */
+    @Test
+    public void testToEntityWithValidDto() {
+        List<String> stations = Arrays.asList("Station1", "Station2", "Station3");
+        List<Integer> distances = Arrays.asList(10, 20, 30);
+        RouteDTO routeDTO = new RouteDTO("test-id", stations, distances, "Station1", "Station3");
+
+        Route result = routeMapper.toEntity(routeDTO);
+
+        Assert.assertNotNull("Route should not be null", result);
+        Assert.assertEquals("ID should match", "test-id", result.getId());
+        Assert.assertEquals("Stations should match", stations, result.getStations());
+        Assert.assertEquals("Distances should match", distances, result.getDistances());
+        Assert.assertEquals("Start station should match", "Station1", result.getStartStation());
+        Assert.assertEquals("End station should match", "Station3", result.getEndStation());
+    }
+
+    /**
+     * Test toEntity method with null DTO
+     */
+    @Test
+    public void testToEntityWithNullDto() {
+        Route result = routeMapper.toEntity(null);
+        Assert.assertNull("Route should be null when input is null", result);
+    }
+
+    /**
+     * Test round-trip conversion to ensure data integrity
+     */
+    @Test
+    public void testRoundTripConversion() {
+        List<String> stations = Arrays.asList("X", "Y", "Z");
+        List<Integer> distances = Arrays.asList(100, 200, 300);
+        Route originalRoute = new Route("round-trip-id", stations, distances, "X", "Z");
+
+        RouteDTO dto = routeMapper.toDto(originalRoute);
+        Route convertedRoute = routeMapper.toEntity(dto);
+
+        Assert.assertEquals("ID should be preserved", originalRoute.getId(), convertedRoute.getId());
+        Assert.assertEquals("Stations should be preserved", originalRoute.getStations(), convertedRoute.getStations());
+        Assert.assertEquals("Distances should be preserved", originalRoute.getDistances(),
+                convertedRoute.getDistances());
+        Assert.assertEquals("Start station should be preserved", originalRoute.getStartStation(),
+                convertedRoute.getStartStation());
+        Assert.assertEquals("End station should be preserved", originalRoute.getEndStation(),
+                convertedRoute.getEndStation());
+    }
+}

--- a/ts-route-service/src/test/java/route/mapper/TestRouteMapperConfiguration.java
+++ b/ts-route-service/src/test/java/route/mapper/TestRouteMapperConfiguration.java
@@ -1,0 +1,18 @@
+package route.mapper;
+
+import org.mapstruct.factory.Mappers;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestRouteMapperConfiguration {
+    
+    /**
+     * Provides RouteMapper instance as a Spring bean
+     * @return RouteMapper instance
+     */
+    @Bean
+    public RouteMapper routeMapper() {
+        return Mappers.getMapper(RouteMapper.class);
+    }
+}

--- a/ts-route-service/src/test/java/route/service/RouteServiceImplTest.java
+++ b/ts-route-service/src/test/java/route/service/RouteServiceImplTest.java
@@ -13,6 +13,8 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpHeaders;
 import route.entity.Route;
 import route.entity.RouteInfo;
+import route.mapper.RouteDTO;
+import route.mapper.RouteMapper;
 import route.repository.RouteRepository;
 
 import java.util.ArrayList;
@@ -28,6 +30,9 @@ public class RouteServiceImplTest {
 
     @Mock
     private RouteRepository routeRepository;
+
+    @Mock
+    private RouteMapper routeMapper;
 
     private HttpHeaders headers = new HttpHeaders();
 
@@ -46,7 +51,9 @@ public class RouteServiceImplTest {
     @Test
     public void testCreateAndModify2() {
         RouteInfo info = new RouteInfo("id", "start_station", "end_station", "shanghai", "5");
+        RouteDTO mockRouteDTO = new RouteDTO();
         Mockito.when(routeRepository.save(Mockito.any(Route.class))).thenReturn(null);
+        Mockito.when(routeMapper.toDto(Mockito.any(Route.class))).thenReturn(mockRouteDTO);
         Response result = routeServiceImpl.createAndModify(info, headers);
         Assert.assertEquals("Save and Modify success", result.getMsg());
     }
@@ -54,8 +61,10 @@ public class RouteServiceImplTest {
     @Test
     public void testCreateAndModify3() {
         RouteInfo info = new RouteInfo("id123456789", "start_station", "end_station", "shanghai", "5");
+        RouteDTO mockRouteDTO = new RouteDTO();
         Mockito.when(routeRepository.findById(Mockito.anyString())).thenReturn(null);
         Mockito.when(routeRepository.save(Mockito.any(Route.class))).thenReturn(null);
+        Mockito.when(routeMapper.toDto(Mockito.any(Route.class))).thenReturn(mockRouteDTO);
         Response result = routeServiceImpl.createAndModify(info, headers);
         Assert.assertEquals("Save and Modify success", result.getMsg());
     }
@@ -87,9 +96,11 @@ public class RouteServiceImplTest {
     @Test
     public void testGetRouteById2() {
         Route route = new Route();
+        RouteDTO mockRouteDTO = new RouteDTO();
         Mockito.when(routeRepository.findById(Mockito.anyString())).thenReturn(Optional.of(route));
+        Mockito.when(routeMapper.toDto(route)).thenReturn(mockRouteDTO);
         Response result = routeServiceImpl.getRouteById("route_id", headers);
-        Assert.assertEquals(new Response<>(1, "Success", Optional.of(route)), result);
+        Assert.assertEquals(new Response<>(1, "Success", mockRouteDTO), result);
     }
 
     @Test
@@ -103,7 +114,10 @@ public class RouteServiceImplTest {
         Route route = new Route(UUID.randomUUID().toString(), stations, distances, "shanghai", "nanjing");
         ArrayList<Route> routes = new ArrayList<>();
         routes.add(route);
+        List<RouteDTO> mockRouteDTOs = new ArrayList<>();
+        mockRouteDTOs.add(new RouteDTO());
         Mockito.when(routeRepository.findAll()).thenReturn(routes);
+        Mockito.when(routeMapper.toDtoList(Mockito.anyList())).thenReturn(mockRouteDTOs);
         Response result = routeServiceImpl.getRouteByStartAndEnd("shanghai", "nanjing", headers);
         Assert.assertEquals("Success", result.getMsg());
     }
@@ -120,7 +134,10 @@ public class RouteServiceImplTest {
     public void testGetAllRoutes1() {
         ArrayList<Route> routes = new ArrayList<>();
         routes.add(new Route());
+        List<RouteDTO> mockRouteDTOs = new ArrayList<>();
+        mockRouteDTOs.add(new RouteDTO());
         Mockito.when(routeRepository.findAll()).thenReturn(routes);
+        Mockito.when(routeMapper.toDtoList(routes)).thenReturn(mockRouteDTOs);
         Response result = routeServiceImpl.getAllRoutes(headers);
         Assert.assertEquals("Success", result.getMsg());
     }


### PR DESCRIPTION
**Description:**
Develop a dedicated mapper class to convert between `Route` entity and a new `RouteDTO` in `ts-route-service`. This utility should handle field mappings and nested value transformations if needed.
**Acceptance Criteria:**
- `RouteDTO` and a corresponding mapper class are present.
- All corresponding service responses for routes use `RouteDTO`.
- Unit tests ensure correct mapping via `RouteMapper` interface.